### PR TITLE
Infer which images need to be pushed

### DIFF
--- a/src/compose_flow/commands/subcommands/compose.py
+++ b/src/compose_flow/commands/subcommands/compose.py
@@ -45,6 +45,7 @@ class Compose(PassthroughBaseSubcommand):
                         has_version_arg = True
                         break
         except FileNotFoundError:
+            self.logger.warning("Failed to find Dockerfile, not using build args.")
             pass
 
         extra_args = extra_args or self.args.extra_args

--- a/src/compose_flow/commands/subcommands/publish.py
+++ b/src/compose_flow/commands/subcommands/publish.py
@@ -7,8 +7,6 @@ import sh
 from .base import BaseSubcommand
 # from .compose import Compose
 
-from compose_flow.errors import CommandError
-
 
 class Publish(BaseSubcommand):
     """
@@ -41,27 +39,14 @@ class Publish(BaseSubcommand):
         return logging.getLogger(f'{__name__}.{self.__class__.__name__}')
 
     def push(self):
-        # infer the registry from the DOCKER_IMAGE env var
-        registry = None
-        env_docker_image = self.env.data['DOCKER_IMAGE']
-        if '/' in env_docker_image:
-            registry = env_docker_image.split('/', 1)[0]
-
         docker_images = set()
         for service_data in self.profile.data['services'].values():
-            docker_images.add(service_data.get('image'))
-
-        if registry is None and len(docker_images) > 1:
-            raise CommandError('multiple docker images detected and registry is unknown')
+            if service_data.get('build'):
+                docker_images.add(service_data.get('image'))
 
         for docker_image in docker_images:
-            if not docker_image.startswith(registry):
-                print(f'skipping {docker_image}')
-
-                continue
-
             if len(docker_images) > 1:
-                print(docker_image)
+                self.logger.info(f'pushing {docker_image}')
 
             if self.args.dry_run:
                 self.logger.info(f'docker push {docker_image}')

--- a/src/compose_flow/entrypoints.py
+++ b/src/compose_flow/entrypoints.py
@@ -21,7 +21,7 @@ def compose_flow():
     """
     Main entrypoint
     """
-    logging.basicConfig(level=logging.WARN)
+    logging.basicConfig(level=logging.INFO)
 
     try:
         response = ComposeFlow().run()

--- a/src/compose_flow/entrypoints.py
+++ b/src/compose_flow/entrypoints.py
@@ -4,6 +4,7 @@ Entrypoints module
 Main console script entrypoints for the dc tool
 """
 import logging
+import logging.config
 import sys
 
 from compose_flow import errors
@@ -14,6 +15,7 @@ RUNTIME_VERSION = (sys.version_info.major, sys.version_info.minor)
 if RUNTIME_VERSION < MIN_VERSION:
     sys.exit('Error: compose-flow runs on Python3.6+')
 
+from . import settings
 from .commands import ComposeFlow
 
 
@@ -21,7 +23,7 @@ def compose_flow():
     """
     Main entrypoint
     """
-    logging.basicConfig(level=logging.INFO)
+    logging.config.dictConfig(settings.LOGGING)
 
     try:
         response = ComposeFlow().run()

--- a/src/compose_flow/settings.py
+++ b/src/compose_flow/settings.py
@@ -1,0 +1,24 @@
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'handlers': {
+        'console': {
+            'level': 'DEBUG',
+            'class': 'logging.StreamHandler',
+        },
+    },
+
+    'loggers': {
+        'compose_flow': {
+            'handlers': ['console'],
+            'level': 'INFO',
+            'propagate': False,
+        },
+    },
+
+    'root': {
+        'handlers': ['console'],
+        'level': 'WARNING',
+        'propagate': True,
+    },
+}


### PR DESCRIPTION
When a compose setup is building multiple images, support being able to publish them all.

- [ ] update so that this doesn't infer based on the registry found in the image name and instead go by whether a service has a `build` directive.