### PR TITLE
HOTFIX: Add back compose as a profile subcommand for tasks so YAML gets rendered

### DIFF
--- a/src/compose_flow/commands/subcommands/task.py
+++ b/src/compose_flow/commands/subcommands/task.py
@@ -12,7 +12,7 @@ from compose_flow.errors import CommandError
 
 
 ALLOWED_COMMANDS = ['compose-flow', 'rancher']
-PROFILE_SUBCOMMANDS = ['compose-flow']
+PROFILE_SUBCOMMANDS = ['compose-flow', 'compose']
 
 class Task(BaseSubcommand):
     @classmethod


### PR DESCRIPTION
This is a pretty critical issue that needs to be merged to move forward with `3.x.x`

Without this fix most Jenkins pipelines that use `cf` would break