### PR TITLE
Make some tweaks to be consistent with docker image name

### DIFF
--- a/src/compose_flow/commands/subcommands/env.py
+++ b/src/compose_flow/commands/subcommands/env.py
@@ -87,12 +87,6 @@ class Env(ConfigBaseSubcommand):
 
         data = self.load()
 
-        args = self.workflow.args
-
-        action = None
-        if 'action' in args:
-            action = args.action
-
         # render placeholders
         for k, v in data.items():
             if not v.startswith('runtime://'):

--- a/src/compose_flow/commands/subcommands/env.py
+++ b/src/compose_flow/commands/subcommands/env.py
@@ -129,6 +129,9 @@ class Env(ConfigBaseSubcommand):
                 data[k] = v
 
         if self.workflow.subcommand.update_version_env_vars:
+            # regenerate the full docker image name
+            self._docker_image = None
+
             data.update(
                 {
                     DOCKER_IMAGE_VAR: self.set_docker_tag(self.docker_image),

--- a/src/compose_flow/utils.py
+++ b/src/compose_flow/utils.py
@@ -1,7 +1,6 @@
 import logging
 import re
 import os
-import sys
 import yaml
 
 from collections import OrderedDict

--- a/src/tests/test_env.py
+++ b/src/tests/test_env.py
@@ -8,6 +8,7 @@ from compose_flow.commands import Workflow
 from tests import BaseTestCase
 
 
+@mock.patch('compose_flow.commands.workflow.PROJECT_NAME', new='testdirname')
 class EnvTestCase(BaseTestCase):
     def test_config_name_arg(self, *mocks):
         """
@@ -39,7 +40,6 @@ class EnvTestCase(BaseTestCase):
 
         env.load.assert_not_called()
 
-    @mock.patch('compose_flow.commands.workflow.PROJECT_NAME', new='testdirname')
     def test_default_config_name(self, *mocks):
         """
         Ensure the default config is given
@@ -110,4 +110,4 @@ class EnvTestCase(BaseTestCase):
         env.update_workflow_env()
 
         self.assertEqual(utils_mock.get_tag_version.return_value, env.data['VERSION'])
-        self.assertEqual(f'test.registry.prefix.com/tests:{new_version}', env.data['DOCKER_IMAGE'])
+        self.assertEqual(f'test.registry.prefix.com/testdirname:{new_version}', env.data['DOCKER_IMAGE'])

--- a/src/tests/test_env.py
+++ b/src/tests/test_env.py
@@ -110,4 +110,4 @@ class EnvTestCase(BaseTestCase):
         env.update_workflow_env()
 
         self.assertEqual(utils_mock.get_tag_version.return_value, env.data['VERSION'])
-        self.assertEqual(f'foo:{new_version}', env.data['DOCKER_IMAGE'])
+        self.assertEqual(f'test.registry.prefix.com/tests:{new_version}', env.data['DOCKER_IMAGE'])

--- a/src/tests/test_publish.py
+++ b/src/tests/test_publish.py
@@ -63,6 +63,11 @@ class PublishTestCase(BaseTestCase):
         """
         Ensures that version in env is updated when the publish command is run
         """
+        os_mock = mocks[-1]
+        os_mock.environ = {
+            'CF_DOCKER_IMAGE_PREFIX': 'test.registry',
+        }
+
         version = '1.2.3'
         new_version = '0.9.999'
         docker_image = 'foo:bar'
@@ -88,4 +93,4 @@ class PublishTestCase(BaseTestCase):
         env = flow.environment
 
         self.assertEqual(utils_mock.get_tag_version.return_value, env.data['VERSION'])
-        self.assertEqual(f'foo:{new_version}', env.data['DOCKER_IMAGE'])
+        self.assertEqual(f'test.registry/tests:{new_version}', env.data['DOCKER_IMAGE'])

--- a/src/tests/test_publish.py
+++ b/src/tests/test_publish.py
@@ -9,6 +9,7 @@ from tests import BaseTestCase
 
 
 @mock.patch('compose_flow.commands.subcommands.env.os')
+@mock.patch('compose_flow.commands.workflow.PROJECT_NAME', new='testdirname')
 class PublishTestCase(BaseTestCase):
     @mock.patch('compose_flow.commands.subcommands.env.utils')
     @mock.patch('compose_flow.commands.subcommands.env.docker')
@@ -93,4 +94,4 @@ class PublishTestCase(BaseTestCase):
         env = flow.environment
 
         self.assertEqual(utils_mock.get_tag_version.return_value, env.data['VERSION'])
-        self.assertEqual(f'test.registry/tests:{new_version}', env.data['DOCKER_IMAGE'])
+        self.assertEqual(f'test.registry/testdirname:{new_version}', env.data['DOCKER_IMAGE'])


### PR DESCRIPTION
Use the same convention for building the image name between publishing and
deploying.  The previous revision would dynamically geneate the image name when
publishing, but only update the tag while deploying.

This patch dynamically geneates the name during publishing as well such that it
matches with publishing.

The reason the image name is dynamically generated during publishing is that
there is no need to be connected to a remote machine or access the config for
building and publishing.