### PR TITLE
Don't require a profile to be defined for Rancher deployments

### DIFF
--- a/src/compose_flow/commands/subcommands/deploy.py
+++ b/src/compose_flow/commands/subcommands/deploy.py
@@ -5,7 +5,7 @@ from .kube_mixin import KubeMixIn
 from .profile import Profile
 
 ACTIONS = ['rancher', 'docker', 'rke', 'helm']
-PROFILE_ACTIONS = ['docker', 'rancher']
+PROFILE_ACTIONS = ['docker']
 
 
 class Deploy(BaseSubcommand, KubeMixIn):


### PR DESCRIPTION
We had started requiring a profile for Rancher to get access to `DOCKER_SERVICE` and such, but on second thought we should use a more k8s native solution like `kustomize` https://github.com/kubernetes-sigs/kustomize