### PR TITLE
HOTFIX: ignore artifact directories to avoid publish failure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ __pycache__
 .local
 .cache
 results
+build/
+dist/


### PR DESCRIPTION
Since we run `python setup.py install` inside the container we now have to ignore the `build` and `dist` directories to avoid `tag-version` failing on unclean working directory