### PR TITLE
Add simple build subcommand

### DIFF
--- a/src/compose_flow/commands/subcommands/build.py
+++ b/src/compose_flow/commands/subcommands/build.py
@@ -9,6 +9,7 @@ class Build(BaseSubcommand):
     Subcommand for building Docker images
     """
 
+    dirty_working_copy_okay = True
     rw_env = True
     remote_action = True
     update_version_env_vars = True

--- a/src/compose_flow/commands/subcommands/build.py
+++ b/src/compose_flow/commands/subcommands/build.py
@@ -1,0 +1,42 @@
+
+from functools import lru_cache
+
+from .base import BaseSubcommand
+
+
+class Build(BaseSubcommand):
+    """
+    Subcommand for building Docker images
+    """
+
+    rw_env = True
+    remote_action = True
+    update_version_env_vars = True
+
+    def build(self):
+        compose = self.compose
+
+        compose.handle(extra_args=['build', '--pull'])
+
+    @property
+    @lru_cache()
+    def compose(self):
+        """
+        Returns a Compose subcommand
+        """
+        from .compose import Compose
+
+        return Compose(self.workflow)
+
+    def handle(self):
+        self.build()
+
+    def do_validate_profile(self):
+        return False
+
+    @classmethod
+    def fill_subparser(cls, parser, subparser) -> None:
+        pass
+
+    def is_missing_env_arg_okay(self):
+        return True


### PR DESCRIPTION
It gets old having to run `compose-flow compose build --pull` just to build the project's images

This allows you to just run `compose-flow build`

Resolves openslate/openslate#1786

Lifted pretty much line-for-line from `publish.py`