### PR TITLE
Rework config name vs project name logic

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,13 @@
 @Library('OpenSlateProd')_  // https://github.com/openslate/jenkins-shared-library
 
+def customLintFunction = {
+    cf 'test', "compose run -u root:docker --rm app /bin/bash -c 'pylama -r results/pylama.log || /bin/true'"
+}
+
+def customTestFunction = {
+    cf 'test', "compose run -u root:docker --rm app /bin/bash -c 'nosetests -v ./src --with-xunit --xunit-file=results/report.xml || /bin/true'"
+}
+
 def customPublishTask = {
     cfPublish()
     cf env.DEPLOY_ENV, 'task publish'
@@ -11,7 +19,9 @@ openslatePipeline {
     mentions = '@roberto <@marcusian>'
     deployEnv = 'prod'
     lint = true
+    lintFunction = customLintFunction
     test = true
+    testFunction = customTestFunction
     publish = publishWhen
     publishFunction = customPublishTask
     deploy = false

--- a/src/compose_flow/commands/subcommands/compose.py
+++ b/src/compose_flow/commands/subcommands/compose.py
@@ -29,7 +29,10 @@ class Compose(PassthroughBaseSubcommand):
     def get_command(self):
         command = super().get_command()
 
-        command.extend(['--project-name', self.workflow.args.config_name])
+        compose_project = (self.workflow.args.project_name
+                           if self.workflow.args.project_name
+                           else self.workflow.config_name)
+        command.extend(['--project-name', compose_project])
 
         profile = self.workflow.profile
         command.extend(['-f', profile.filename])

--- a/src/compose_flow/commands/subcommands/compose.py
+++ b/src/compose_flow/commands/subcommands/compose.py
@@ -29,7 +29,8 @@ class Compose(PassthroughBaseSubcommand):
     def get_command(self):
         command = super().get_command()
 
-        compose_project = (self.workflow.args.project_name
+        # If custom project name is provided, respect it. Otherwise use config name
+        compose_project = (self.workflow.project_name
                            if self.workflow.args.project_name
                            else self.workflow.config_name)
         command.extend(['--project-name', compose_project])

--- a/src/compose_flow/commands/subcommands/env.py
+++ b/src/compose_flow/commands/subcommands/env.py
@@ -152,7 +152,7 @@ class Env(ConfigBaseSubcommand):
             return self._docker_image
 
         registry_domain = os.environ['CF_DOCKER_IMAGE_PREFIX']
-        project_name = self.workflow.args.project_name
+        project_name = self.workflow.project_name
         env = self.workflow.args.environment
 
         docker_image = f'{registry_domain}/{project_name}:{env}'

--- a/src/compose_flow/commands/workflow.py
+++ b/src/compose_flow/commands/workflow.py
@@ -187,8 +187,9 @@ class Workflow(object):
 
         NOTE: an environment can be None!
         """
-        if self.args.project_name is None:
-            self.args.project_name = PROJECT_NAME
+        self.project_name = self.args.project_name
+        if self.project_name is None:
+            self.project_name = PROJECT_NAME
 
         # when no profile or remote is given, they take on the same as the environment name
         if self.args.profile is None:
@@ -203,7 +204,7 @@ class Workflow(object):
             if self.args.environment:
                 prefix = f'{self.args.environment}-'
 
-            self.args.config_name = f'{prefix}{self.args.project_name}'
+            self.args.config_name = f'{prefix}{self.project_name}'
 
     def _setup_environment(self):
         """

--- a/src/tests/test_workflow.py
+++ b/src/tests/test_workflow.py
@@ -106,7 +106,7 @@ class WorkflowArgsTestCase(TestCase):
         self.assertEqual(None, workflow.args.environment)
         self.assertEqual(None, workflow.args.remote)
         self.assertEqual(TEST_PROJECT_NAME, workflow.args.config_name)
-        self.assertEqual(TEST_PROJECT_NAME, workflow.args.project_name)
+        self.assertEqual(TEST_PROJECT_NAME, workflow.project_name)
 
     def test_sensible_defaults_with_env(self, *mocks):
         """
@@ -119,7 +119,7 @@ class WorkflowArgsTestCase(TestCase):
         self.assertEqual(env, workflow.args.environment)
         self.assertEqual(env, workflow.args.remote)
         self.assertEqual(f'{env}-{TEST_PROJECT_NAME}', workflow.args.config_name)
-        self.assertEqual(TEST_PROJECT_NAME, workflow.args.project_name)
+        self.assertEqual(TEST_PROJECT_NAME, workflow.project_name)
 
     def test_sensible_defaults_with_env_and_project(self, *mocks):
         """
@@ -132,4 +132,4 @@ class WorkflowArgsTestCase(TestCase):
         self.assertEqual(env, workflow.args.environment)
         self.assertEqual(env, workflow.args.remote)
         self.assertEqual(f'{env}-foo', workflow.args.config_name)
-        self.assertEqual('foo', workflow.args.project_name)
+        self.assertEqual('foo', workflow.project_name)


### PR DESCRIPTION
Trying to resolve the inconsistencies with how compose services get named

Also adds temporary Jenkinsfile logic to address issues with `task` subcommand

Contributes to openslate/openslate#1893