### PR TITLE
Remove task from publish function

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ def customTestFunction = {
 
 def customPublishTask = {
     cfPublish()
-    sh "compose-flow -e ${env.DEPLOY_ENV} --project-name ${env.REPO_NAME} task publish"
+    sh "compose-flow -e ${env.DEPLOY_ENV} --project-name ${env.REPO_NAME} compose run -u root:docker --rm app /bin/bash ./scripts/publish.sh"
 }
 
 def publishWhen = { env.TAG_NAME }


### PR DESCRIPTION
Ugh something is wrong with `task` - it tried to publish an old version number for some reason, maybe ran the wrong image?

Anyway calling the script directly solved it