### PR TITLE
Fix broken refs to project_name arg

### DIFF
--- a/src/compose_flow/commands/subcommands/env.py
+++ b/src/compose_flow/commands/subcommands/env.py
@@ -72,9 +72,9 @@ class Env(ConfigBaseSubcommand):
 
         return {
             'CF_ENV': args.environment or '',
-            'CF_PROJECT': args.project_name,
+            'CF_PROJECT': self.workflow.project_name,
             # deprecate this env var
-            'CF_ENV_NAME': args.project_name,
+            'CF_ENV_NAME': self.workflow.project_name,
         }
 
     @property


### PR DESCRIPTION
After changing the `compose` subcommand to use `project_name` several bugs emerged, likely caused by these lingering references to `workflow.args.project_name` which now may be null