### PR TITLE
Auto-tag major, minor, and latest on publish.

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -11,6 +11,7 @@ sh = "*"
 tag-version = "*"
 tabulate = "*"
 docker-compose = "*"
+semantic-version = "*"
 
 [dev-packages]
 twine = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "f17a65a9f2aece066a2b51a794e52bed782094a6ac48350f1961715b4bb84cc7"
+            "sha256": "70fd3b123d45ffd46b44d0bc716de53adf1a5a272ef8a5843e5e91c72ef77131"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -157,6 +157,14 @@
                 "sha256:ea881206e59f41dbd0bd445437d792e43906703fff75ca8ff43ccdb11f33f263"
             ],
             "version": "==2.20.1"
+        },
+        "semantic-version": {
+            "hashes": [
+                "sha256:2a4328680073e9b243667b201119772aefc5fc63ae32398d6afafff07c4f54c0",
+                "sha256:2d06ab7372034bcb8b54f2205370f4aa0643c133b7e6dbd129c5200b83ab394b"
+            ],
+            "index": "pypi",
+            "version": "==2.6.0"
         },
         "sh": {
             "hashes": [

--- a/src/compose_flow/commands/subcommands/publish.py
+++ b/src/compose_flow/commands/subcommands/publish.py
@@ -67,7 +67,7 @@ class Publish(BaseSubcommand):
             image_name = image.split(':')[0]
 
             tag = image.split(':')[-1]
-            semver = re.match(r'(\d+)\.(\d+)\.?(\d*)', tag)
+            semver = re.match(r'^(\d+)\.(\d+)\.?(\d*)$', tag)
 
             if semver:
                 if semver.group(2):

--- a/src/compose_flow/commands/subcommands/publish.py
+++ b/src/compose_flow/commands/subcommands/publish.py
@@ -1,4 +1,5 @@
 import logging
+import re
 
 from functools import lru_cache
 
@@ -13,6 +14,16 @@ class Publish(BaseSubcommand):
     rw_env = True
     remote_action = True
     update_version_env_vars = True
+
+    def auto_tag(self):
+
+        built_images = self.get_built_docker_images()
+        new_tags = self.get_auto_tag_docker_images(built_images)
+
+        for docker_image, auto_tag_images in new_tags.items():
+            for auto_tag in auto_tag_images:
+                # tag all our images
+                self.execute(f'docker tag {docker_image} {auto_tag}', _fg=True)
 
     def build(self):
         compose = self.compose
@@ -34,7 +45,41 @@ class Publish(BaseSubcommand):
 
     @classmethod
     def fill_subparser(cls, parser, subparser) -> None:
-        pass
+        subparser.add_argument(
+            '--skip-auto-tag',
+            action='store_true',
+            help='do not publish major, minor, and latest tags for images built by compose-flow',
+        )
+
+    def get_auto_tag_docker_images(self, built_images: list) -> dict:
+        """
+        Returns a dict of original docker image names pointing to list of new tags to push.
+        """
+
+        # if we received a skip auto tags flag, simply return the images without any tags
+        if self.workflow.args.skip_auto_tag:
+            return dict([(image, []) for image in built_images])
+
+        new_tags = {}
+
+        for image in built_images:
+            auto_tags = []
+            image_name = image.split(':')[0]
+
+            tag = image.split(':')[-1]
+            semver = re.match(r'(\d+)\.(\d+)\.?(\d*)', tag)
+
+            if semver:
+                if semver.group(2):
+                    auto_tags.append(f'{image_name}:{semver.group(1)}')
+                if semver.group(3):
+                    auto_tags.append(f'{image_name}:{semver.group(1)}.{semver.group(2)}')
+
+            auto_tags.append(':'.join([image_name, 'latest']))
+
+            new_tags[image] = auto_tags
+
+        return new_tags
 
     def get_built_docker_images(self) -> list:
         """
@@ -49,8 +94,22 @@ class Publish(BaseSubcommand):
 
         return list(docker_images)
 
+    def get_docker_images_for_push(self):
+        built_images = self.get_built_docker_images()
+        new_tags = self.get_auto_tag_docker_images(built_images)
+
+        push_tags = []
+
+        for k, v in new_tags.items():
+            push_tags.append(k)
+            push_tags += v
+
+        return push_tags
+
     def handle(self):
         self.build()
+
+        self.auto_tag()
 
         self.push()
 
@@ -62,11 +121,10 @@ class Publish(BaseSubcommand):
         return logging.getLogger(f'{__name__}.{self.__class__.__name__}')
 
     def push(self):
-        docker_images = self.get_built_docker_images()
-        for docker_image in docker_images:
-            if len(docker_images) > 1:
-                self.logger.info(f'pushing {docker_image}')
+        docker_images = self.get_docker_images_for_push()
 
+        for docker_image in docker_images:
+            # push up all images along with major, minor, latest by default
             if self.workflow.args.dry_run:
                 self.logger.info(f'docker push {docker_image}')
             else:

--- a/src/compose_flow/commands/subcommands/publish.py
+++ b/src/compose_flow/commands/subcommands/publish.py
@@ -70,15 +70,19 @@ class Publish(BaseSubcommand):
 
             tag = image.split(':')[-1]
 
-            semver = semantic_version.Version(tag)
+            try:
+                semver = semantic_version.Version(tag)
 
-            # only build major and minor if this is a clean patch or minor release
-            if not (semver.prerelease and semver.build):
-                auto_tags.append(f'{image_name}:{semver.major}')
+                # only build major and minor if this is a clean patch or minor release
+                if not (semver.prerelease and semver.build):
+                    auto_tags.append(f'{image_name}:{semver.major}')
 
-                auto_tags.append(f'{image_name}:{semver.major}.{semver.minor}')
+                    auto_tags.append(f'{image_name}:{semver.major}.{semver.minor}')
 
-            auto_tags.append(':'.join([image_name, 'latest']))
+                auto_tags.append(':'.join([image_name, 'latest']))
+
+            except ValueError:
+                self.logger.warning(f'{tag} is not a valid semver, skipping auto-tags.')
 
             new_tags[image] = auto_tags
 

--- a/src/compose_flow/commands/subcommands/publish.py
+++ b/src/compose_flow/commands/subcommands/publish.py
@@ -1,6 +1,8 @@
 import logging
 import re
 
+import semantic_version
+
 from functools import lru_cache
 
 from .base import BaseSubcommand
@@ -67,13 +69,14 @@ class Publish(BaseSubcommand):
             image_name = image.split(':')[0]
 
             tag = image.split(':')[-1]
-            semver = re.match(r'^(\d+)\.(\d+)\.?(\d*)$', tag)
 
-            if semver:
-                if semver.group(2):
-                    auto_tags.append(f'{image_name}:{semver.group(1)}')
-                if semver.group(3):
-                    auto_tags.append(f'{image_name}:{semver.group(1)}.{semver.group(2)}')
+            semver = semantic_version.Version(tag)
+
+            # only build major and minor if this is a clean patch or minor release
+            if not (semver.prerelease and semver.build):
+                auto_tags.append(f'{image_name}:{semver.major}')
+
+                auto_tags.append(f'{image_name}:{semver.major}.{semver.minor}')
 
             auto_tags.append(':'.join([image_name, 'latest']))
 

--- a/src/tests/test_publish.py
+++ b/src/tests/test_publish.py
@@ -24,6 +24,7 @@ class PublishTestCase(BaseTestCase):
         flow = Workflow(argv=command)
 
         flow.subcommand.build = mock.Mock()
+        flow.subcommand.auto_tag = mock.Mock()
         flow.subcommand.push = mock.Mock()
 
         flow.run()


### PR DESCRIPTION
- Automatically tag major, minor, and latest releases on publish by default
- Skip auto tagging with --skip-auto-tag flag

- [ ] ready to merge