### PR TITLE
Fix base 64 encoding filter to return proper string

### DIFF
--- a/src/compose_flow/utils.py
+++ b/src/compose_flow/utils.py
@@ -154,7 +154,7 @@ def render_jinja(content: str, env: dict = None) -> str:
         env = {}
 
     jinja_env = Environment()
-    jinja_env.filters['b64encode'] = lambda s: base64.b64encode(s.encode())
+    jinja_env.filters['b64encode'] = lambda s: base64.b64encode(s.encode()).decode('utf-8')
 
     return jinja_env.from_string(content).render(env)
 


### PR DESCRIPTION
Need to get this in quick since it's causing problems with k8s deployments that use Secrets