### PR TITLE
Get remote user from appconfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,10 +119,10 @@ Then you could paste something like the following:
 ```
 remotes:
   dev:
-    ssh: ${CF_REMOTE_USER}@dev-swarm-manager-1
+    ssh: username@dev-swarm-manager-1
 
   prod:
-    ssh: ${CF_REMOTE_USER}@prod-swarm-manager-1
+    ssh: username@prod-swarm-manager-1
 ```
 
 With this configuration in place the above `deploy` example would deploy to `prod-swarm-manager-1`, while using `compose-flow -e dev deploy` would deploy to `dev-swarm-manager-1`.

--- a/src/compose_flow/commands/subcommands/remote.py
+++ b/src/compose_flow/commands/subcommands/remote.py
@@ -96,6 +96,9 @@ class Remote(BaseSubcommand):
 
     @property
     def host(self):
+        """
+        Returns the host information to SSH into
+        """
         if self._host is not None:
             return self._host
 

--- a/src/compose_flow/commands/subcommands/remote.py
+++ b/src/compose_flow/commands/subcommands/remote.py
@@ -9,6 +9,7 @@ from .base import BaseSubcommand
 
 from compose_flow import errors, shell
 from compose_flow.errors import EnvError, ErrorMessage
+from compose_flow import settings
 
 UNIX_PREFIX = 'unix://'
 UNIX_REMOTE_HOST_RE = re.compile(UNIX_PREFIX + r'(?P<socket>.*)')
@@ -221,3 +222,20 @@ class Remote(BaseSubcommand):
             print(message)
 
         return status
+
+    @property
+    def username(self):
+        """
+        Returns the remote username
+
+        When the remote host contains a username, e.g. user@hostname, the user
+        component is extracted.  When a username is not found in the remote
+        configuration, the settings are referenced.
+        """
+        username = settings.DEFAULT_CF_REMOTE_USER
+
+        host = self.host
+        if host and '@' in host:
+            username = host.split('@', 1)[0]
+
+        return username

--- a/src/compose_flow/commands/subcommands/service.py
+++ b/src/compose_flow/commands/subcommands/service.py
@@ -171,7 +171,7 @@ class Service(BaseSubcommand):
         if container_host.startswith('ip-'):
             container_host = container_host.replace('ip-', '').replace('-', '.')
 
-        host_info = f'{CF_REMOTE_USER}@{container_host}'
+        host_info = f'{self.workflow.remote.username}@{container_host}'
 
         docker_user = ''
         if args.user:

--- a/src/compose_flow/commands/subcommands/service.py
+++ b/src/compose_flow/commands/subcommands/service.py
@@ -41,9 +41,6 @@ import time
 from .base import BaseSubcommand
 from compose_flow import errors, shell
 
-USER = os.environ.get('USER', 'nobody')
-CF_REMOTE_USER = os.environ.get('CF_REMOTE_USER', USER)
-
 
 class Service(BaseSubcommand):
     setup_environment = False

--- a/src/compose_flow/commands/workflow.py
+++ b/src/compose_flow/commands/workflow.py
@@ -152,6 +152,11 @@ class Workflow(object):
     def profile(self):
         return Profile(self)
 
+    @property
+    @lru_cache()
+    def remote(self):
+        return Remote(self)
+
     def run(self):
         # setup the loglevel
         logging_config = settings.LOGGING
@@ -238,17 +243,15 @@ class Workflow(object):
         if not self.subcommand.remote_action:
             return
 
-        remote = Remote(self)
-
         try:
-            remote.make_connection(use_existing=True)
+            self.remote.make_connection(use_existing=True)
         except (errors.AlreadyConnected, errors.RemoteUndefined):
             pass
         except errors.NotConnected as exc:
             if not self.is_not_connected_okay(exc):  # pylint: disable=E1101
                 raise
 
-        docker_host = remote.docker_host
+        docker_host = self.remote.docker_host
         if docker_host:
             # one of the very few exceptions of updating the os environment directly
             # the docker host is low level in that it's not possible to run docker

--- a/src/compose_flow/settings.py
+++ b/src/compose_flow/settings.py
@@ -1,3 +1,6 @@
+import os
+
+
 LOGGING = {
     'version': 1,
     'disable_existing_loggers': False,
@@ -7,3 +10,6 @@ LOGGING = {
     },
     'root': {'handlers': ['console'], 'level': 'WARNING', 'propagate': True},
 }
+
+USER = os.environ.get('USER', 'nobody')
+DEFAULT_CF_REMOTE_USER = os.environ.get('CF_REMOTE_USER', USER)

--- a/src/tests/test_remote.py
+++ b/src/tests/test_remote.py
@@ -1,0 +1,60 @@
+from functools import lru_cache
+from unittest import TestCase, mock
+
+from compose_flow.commands.subcommands.remote import Remote
+
+TEST_USERNAME = 'testuser'
+
+
+@mock.patch('compose_flow.settings.DEFAULT_CF_REMOTE_USER', new=TEST_USERNAME)
+class RemoteTestCase(TestCase):
+    @property
+    @lru_cache()
+    def workflow(self):
+        return mock.Mock()
+
+    def test_default_username(self):
+        """
+        Ensure when no app config is found, the username from settings module is used
+        """
+        self.workflow.app_config = {}
+
+        remote = Remote(self.workflow)
+
+        self.assertEqual(remote.username, TEST_USERNAME)
+
+    def test_appconfig_remote_without_username(self):
+        """
+        Ensure username falls back to the settings user when there is no '@' in the remote hostname
+        """
+        self.workflow.args.environment = 'dev'
+        self.workflow.app_config = {
+            'remotes': {
+                'dev': {
+                    'ssh': f'testremotehost'
+                },
+            },
+        }
+
+        remote = Remote(self.workflow)
+
+        self.assertEqual(remote.username, TEST_USERNAME)
+
+    def test_username_from_appconfig(self):
+        """
+        Ensure username is extracted from remote host
+        """
+        username = 'testuserfoo'
+
+        self.workflow.args.environment = 'dev'
+        self.workflow.app_config = {
+            'remotes': {
+                'dev': {
+                    'ssh': f'{username}@testremotehost'
+                },
+            },
+        }
+
+        remote = Remote(self.workflow)
+
+        self.assertEqual(remote.username, username)


### PR DESCRIPTION
Removes the need to set $CF_REMOTE_USER and infers the remote username from the ssh configuration in the application config.