### PR TITLE
Allow users to exec into rancher pods

### DIFF
--- a/src/compose_flow/commands/subcommands/pod.py
+++ b/src/compose_flow/commands/subcommands/pod.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""
+Subcommand for working with pods
+
+This subcommand provides two actions:
+
+- exec
+
+The `exec` action will execute the given command within the specified pod.
+For example, the following command will launch an interactive shell in the `app`
+container:
+
+```
+compose-flow -e dev service exec ad-api web /bin/bash
+```
+"""
+import argparse
+import logging
+import os
+import re
+import time
+
+from compose_flow.kube.mixins import KubeMixIn
+from .base import BaseSubcommand
+from compose_flow import errors, shell
+
+
+class Pod(BaseSubcommand, KubeMixIn):
+
+    command_name = 'pod'
+
+    setup_environment = True
+
+    setup_profile = False
+
+    @classmethod
+    def fill_subparser(cls, parser, subparser):
+        subparser.epilog = __doc__
+        subparser.formatter_class = argparse.RawDescriptionHelpFormatter
+
+        subparser.add_argument(
+            '--container',
+            type=str,
+            default=None,
+            help='which container to exec into within a pod',
+        )
+        subparser.add_argument(
+            '-i',
+            '--container-index',
+            type=int,
+            default=0,
+            help="exec into the i'th container",
+        )
+        subparser.add_argument(
+            '--retries', type=int, default=30, help='number of times to retry'
+        )
+
+        # ToDo: make this a subparser itself
+        subparser.add_argument('action', help='action to run. options: [exec,]')
+        subparser.add_argument('namespace', help='namespace to target')
+        subparser.add_argument('pod_name', help='name of desired pod, e.g. `web`')
+
+    def action_exec(self):
+        args = self.workflow.args
+
+        self.switch_kube_context()
+
+        for i in range(args.retries):
+            try:
+                self.run_pod()
+            except errors.NoContainer:
+                time.sleep(1.0)
+            else:
+                break
+
+    def format_pods_output(self, list_raw, include_header=False):
+        list_raw = list_raw.split('\n')
+        list_raw = [row_str.split(' ') for row_str in list_raw]
+
+        if not include_header:
+            list_raw = list_raw[1:]
+
+        cleaned_output = []
+        for row in list_raw:
+            cleaned_row = [element for element in row if element]
+            cleaned_output.append(cleaned_row)
+
+        return [row for row in cleaned_output if row]
+
+    def run_pod(self):
+        args = self.workflow.args
+
+        pod = self.select_pod()
+
+        if args.container:
+            target_container = f'--container {args.container}'
+        else:
+            target_container = ''
+
+        command = (
+                f'rancher kubectl -n {args.namespace} exec -it {pod} {target_container} -- '
+                f'{" ".join(self.workflow.args_remainder)}'
+            )
+
+        logging.debug(f'command={command}')
+
+        return shell.execute(command, os.environ, _fg=True)
+
+    def select_pod(self):
+        args = self.workflow.args
+        pods_list_raw = self.list_pods(namespace=args.namespace)
+        pods_list = self.format_pods_output(pods_list_raw)
+
+        pod_name_re = rf'^{args.pod_name}\-.*\-.*$'
+
+        matched_pods = [p for p in pods_list if re.match(pod_name_re, p[0])]
+
+        return matched_pods[args.container_index][0]

--- a/src/compose_flow/kube/mixins.py
+++ b/src/compose_flow/kube/mixins.py
@@ -294,6 +294,13 @@ class KubeMixIn(object):
     def get_helm_app_upgrade_command(self, app_name: str, rendered_path: str, chart: str, version: str):
         return f'helm upgrade {app_name} {chart} -f {rendered_path} --version {version}'
 
+    def list_pods(self, namespace: str = None):
+        if namespace:
+            namespace_command = f' -n {namespace} '
+        else:
+            namespace_command = ''
+        return str(self.execute(f'rancher kubectl get pods {namespace_command}'))
+
     def list_rancher_apps(self) -> str:
         return str(self.execute("rancher apps ls --format '{{.App.Name}}'")).split('\n')
 

--- a/src/compose_flow/kube/mixins.py
+++ b/src/compose_flow/kube/mixins.py
@@ -148,12 +148,11 @@ class KubeMixIn(object):
         """
         self.execute(f"{self.kubectl_command} delete secrets --namespace {self.namespace} {self.secret_name}")
 
-
     # Native Kube context management logic
     def switch_kube_context(self):
-        '''
+        """
         Switch current kubectl context to target specified cluster based on environment
-        '''
+        """
         profile_name = self.workflow.args.profile
         context_mapping = self.config.get('kubecontexts', {})
 
@@ -179,13 +178,13 @@ class KubeMixIn(object):
 
     @property
     def cluster_name(self):
-        '''
+        """
         Get the cluster name for the specified target environment.
 
         If profile_name is in the compose-flow.yml Rancher cluster mapping,
         use its value - otherwise check the global remote config,
         then finally use workflow.args.profile if nothing else is defined
-        '''
+        """
         profile_name = self.workflow.args.profile
         default_cluster = self.remotes.get(profile_name, {}).get('rancher', {}).get('cluster')
         cluster_mapping = self.rancher_config.get('clusters', {})
@@ -223,10 +222,10 @@ class KubeMixIn(object):
                                         'to use Rancher as a backend or deployment target!')
 
     def switch_rancher_context(self):
-        '''
+        """
         Switch Rancher CLI context to target specified cluster based on environment
         and specified project name from compose-flow.yml
-        '''
+        """
         # Get the project name specified in compose-flow.yml
         target_project_name = self.project_name
 
@@ -262,10 +261,10 @@ class KubeMixIn(object):
 
     # YAML rendering and deployment methods
     def get_app_deploy_command(self, app: dict, target: str = 'rancher') -> str:
-        '''
+        """
         Construct command to install or upgrade a Rancher app
         depending on whether or not it is already deployed.
-        '''
+        """
 
         app_name = app['name']
         version = app['version']
@@ -307,7 +306,7 @@ class KubeMixIn(object):
         return f'rancher apps upgrade --answers {rendered_path} {app_name} {version}'
 
     def get_kubectl_command(self, manifest: dict, kubectl_prefix: str = 'kubectl') -> str:
-        '''Construct command to apply a Kubernetes YAML manifest using kubectl.'''
+        """Construct command to apply a Kubernetes YAML manifest using kubectl."""
 
         deploy_label = self.workflow.args.config_name
 
@@ -383,10 +382,10 @@ class KubeMixIn(object):
     def render_single_yaml(self, input_path: str, output_path: str,
                            checker: BaseChecker = None, raw: bool = False
                            ) -> None:
-        '''
+        """
         Read in single YAML file from specified path, render environment variables,
         then write out to a known location in the working dir.
-        '''
+        """
         self.logger.info("Rendering YAML at %s to %s", input_path, output_path)
 
         with open(input_path, 'r') as fh:
@@ -409,7 +408,7 @@ class KubeMixIn(object):
 
     @lru_cache()
     def render_manifest(self, manifest_path: str, raw: bool) -> str:
-        '''Render the specified manifest YAML and return the path to the rendered file.'''
+        """Render the specified manifest YAML and return the path to the rendered file."""
         rendered_path = self.get_manifest_filename(manifest_path)
         self.render_single_yaml(manifest_path, rendered_path, ManifestChecker(), raw)
 
@@ -439,7 +438,7 @@ class KubeMixIn(object):
 
     @lru_cache()
     def render_answers(self, answers_path: str, app_name: str, raw: bool) -> str:
-        '''Render the specified manifest YAML and return the path to the rendered file.'''
+        """Render the specified manifest YAML and return the path to the rendered file."""
         rendered_path = self.get_answers_filename(app_name)
         self.render_single_yaml(answers_path, rendered_path, AnswersChecker(), raw)
 

--- a/src/tests/test_pod.py
+++ b/src/tests/test_pod.py
@@ -1,0 +1,45 @@
+import shlex
+from unittest import mock
+
+from compose_flow.commands import Workflow
+from tests import BaseTestCase
+
+
+class PodTestCase(BaseTestCase):
+
+    @mock.patch('compose_flow.shell.execute')
+    @mock.patch('compose_flow.commands.subcommands.pod.Pod.switch_kube_context')
+    def test_exec_pod(self, *mocks):
+        """
+        Basic test to ensure the command runs as expected
+        """
+        argv = shlex.split(
+            '-e test pod exec sample-namespace generic-workers --container generic-workers -i 2 /bin/bash'
+        )
+        workflow = Workflow(argv=argv)
+
+        pod = workflow.subcommand
+
+        pod.list_pods = mock.MagicMock()
+        pod.list_pods.return_value = (
+            'NAME                                          READY     STATUS    RESTARTS   AGE\n'
+            'celerybeat-568bdbc99d-m8x4n                   1/1       Running   0          96m\n'
+            'generic-workers-6c744b8fb8-7sjb8              1/1       Running   0          96m\n'
+            'generic-workers-6c744b8fb8-9rrjx              1/1       Running   0          96m\n'
+            'generic-workers-6c744b8fb8-c66gl              1/1       Running   0          96m\n'
+            'generic-workers-6c744b8fb8-rjrns              1/1       Running   0          96m\n'
+            'published-frontend-reports-5dd4b54fd5-r42gg   1/1       Running   0          96m\n'
+            'redis-master-0                                1/1       Running   0          2d3h\n'
+            'web-b5496d46f-hjt4q                           1/1       Running   0          96m\n'
+            'web-b5496d46f-k9lwq                           1/1       Running   0          96m\n'
+            'web-b5496d46f-spdqd                           1/1       Running   0          96m\n'
+        )
+
+        workflow.run()
+
+        target_command = (
+            'rancher kubectl -n sample-namespace exec -it generic-workers-6c744b8fb8-c66gl ' 
+            '--container generic-workers -- /bin/bash'
+        )
+
+        self.assertEqual(target_command, mocks[1].call_args[0][0])


### PR DESCRIPTION
Up until now we have been using a bash wrapper script
around `cf` to exec into pods on rancher. This PR brings
that logic into cf itself.

Example Usage:
```
cf -e dev pod exec <namespace> <pod_name> -i <pod_index> --container <container_to_exec_into>
cf -e dev pod exec ad-api web /bin/bash
```