### PR TITLE
Fixup the pod exec command.

### DIFF
--- a/src/compose_flow/commands/subcommands/pod.py
+++ b/src/compose_flow/commands/subcommands/pod.py
@@ -35,7 +35,7 @@ class Pod(BaseSubcommand, KubeMixIn):
 
     @property
     def namespace(self):
-        return self.workflow.args.namespace or f'{self.project_name.lower()}'
+        return self.workflow.args.namespace or f'{self.workflow.project_name}'
 
     @classmethod
     def fill_subparser(cls, parser, subparser):

--- a/src/compose_flow/commands/subcommands/pod.py
+++ b/src/compose_flow/commands/subcommands/pod.py
@@ -11,7 +11,7 @@ For example, the following command will launch an interactive shell in the `app`
 container:
 
 ```
-compose-flow -e dev service exec ad-api web /bin/bash
+compose-flow -e dev service exec web /bin/bash
 ```
 """
 import argparse

--- a/src/compose_flow/commands/subcommands/pod.py
+++ b/src/compose_flow/commands/subcommands/pod.py
@@ -57,7 +57,6 @@ class Pod(BaseSubcommand, KubeMixIn):
 
         # ToDo: make this a subparser itself
         subparser.add_argument('action', help='action to run. options: [exec,]')
-        subparser.add_argument('namespace', help='namespace to target')
         subparser.add_argument('pod_name', help='name of desired pod, e.g. `web`')
 
     def action_exec(self):
@@ -98,7 +97,7 @@ class Pod(BaseSubcommand, KubeMixIn):
             target_container = ''
 
         command = (
-                f'{self.kubectl_command} -n {args.namespace} exec -it {pod} {target_container} -- '
+                f'{self.kubectl_command} -n {self.workflow.project_name} exec -it {pod} {target_container} -- '
                 f'{" ".join(self.workflow.args_remainder)}'
             )
 
@@ -108,7 +107,7 @@ class Pod(BaseSubcommand, KubeMixIn):
 
     def select_pod(self):
         args = self.workflow.args
-        pods_list_raw = self.list_pods(namespace=args.namespace)
+        pods_list_raw = self.list_pods(namespace=self.workflow.project_name)
         pods_list = self.format_pods_output(pods_list_raw)
 
         pod_name_re = rf'^{args.pod_name}\-.*\-.*$'

--- a/src/compose_flow/commands/subcommands/pod.py
+++ b/src/compose_flow/commands/subcommands/pod.py
@@ -63,7 +63,7 @@ class Pod(BaseSubcommand, KubeMixIn):
     def action_exec(self):
         args = self.workflow.args
 
-        self.switch_kube_context()
+        self.switch_rancher_context()
 
         for i in range(args.retries):
             try:

--- a/src/compose_flow/commands/subcommands/pod.py
+++ b/src/compose_flow/commands/subcommands/pod.py
@@ -35,7 +35,7 @@ class Pod(BaseSubcommand, KubeMixIn):
 
     @property
     def namespace(self):
-        return self.workflow.args.namespace or f'{self.workflow.project_name}'
+        return self.workflow.args.namespace or self.workflow.project_name
 
     @classmethod
     def fill_subparser(cls, parser, subparser):

--- a/src/compose_flow/commands/subcommands/pod.py
+++ b/src/compose_flow/commands/subcommands/pod.py
@@ -104,7 +104,7 @@ class Pod(BaseSubcommand, KubeMixIn):
             target_container = ''
 
         command = (
-                f'{self.kubectl_command} -n {self.workflow.project_name} exec -it {pod} {target_container} -- '
+                f'{self.kubectl_command} -n {self.namespace} exec -it {pod} {target_container} -- '
                 f'{" ".join(self.workflow.args_remainder)}'
             )
 
@@ -114,7 +114,7 @@ class Pod(BaseSubcommand, KubeMixIn):
 
     def select_pod(self):
         args = self.workflow.args
-        pods_list_raw = self.list_pods(namespace=self.workflow.project_name)
+        pods_list_raw = self.list_pods(namespace=self.namespace)
         pods_list = self.format_pods_output(pods_list_raw)
 
         pod_name_re = rf'^{args.pod_name}\-.*\-.*$'

--- a/src/compose_flow/commands/subcommands/pod.py
+++ b/src/compose_flow/commands/subcommands/pod.py
@@ -33,6 +33,10 @@ class Pod(BaseSubcommand, KubeMixIn):
 
     setup_profile = False
 
+    @property
+    def namespace(self):
+        return self.workflow.args.namespace or f'{self.project_name.lower()}'
+
     @classmethod
     def fill_subparser(cls, parser, subparser):
         subparser.epilog = __doc__
@@ -53,6 +57,9 @@ class Pod(BaseSubcommand, KubeMixIn):
         )
         subparser.add_argument(
             '--retries', type=int, default=30, help='number of times to retry'
+        )
+        subparser.add_argument(
+            '--namespace', type=str, help='override the namespace. defaults to project name.'
         )
 
         # ToDo: make this a subparser itself

--- a/src/compose_flow/commands/subcommands/pod.py
+++ b/src/compose_flow/commands/subcommands/pod.py
@@ -114,4 +114,10 @@ class Pod(BaseSubcommand, KubeMixIn):
 
         matched_pods = [p for p in pods_list if re.match(pod_name_re, p[0])]
 
-        return matched_pods[args.container_index][0]
+        try:
+            target_pod = matched_pods[args.container_index][0]
+            return target_pod
+        except IndexError:
+            raise errors.PodNotFound(
+                f'Could not find pod with index {args.container_index} matching regex {pod_name_re}'
+            )

--- a/src/compose_flow/errors.py
+++ b/src/compose_flow/errors.py
@@ -119,3 +119,7 @@ class RancherNamespaceAlreadyExists(ErrorMessage):
     """
     Raised when a namespace is specified for creation but that namespace already exists.
     """
+
+
+class PodNotFound(ErrorMessage):
+    """Raised when no pod is found matching a certain set of criteria."""

--- a/src/tests/test_pod.py
+++ b/src/tests/test_pod.py
@@ -35,7 +35,7 @@ class PodTestCase(BaseTestCase):
         Basic test to ensure the command runs as expected
         """
         argv = shlex.split(
-            '-e test pod exec sample-namespace generic-workers --container generic-workers -i 2 /bin/bash'
+            '-e test pod exec generic-workers --container generic-workers -i 2 /bin/bash'
         )
         workflow = Workflow(argv=argv)
 
@@ -47,20 +47,20 @@ class PodTestCase(BaseTestCase):
         workflow.run()
 
         target_command = (
-            'rancher kubectl -n sample-namespace exec -it generic-workers-6c744b8fb8-c66gl ' 
+            f'rancher kubectl -n {workflow.project_name} exec -it generic-workers-6c744b8fb8-c66gl ' 
             '--container generic-workers -- /bin/bash'
         )
 
         self.assertEqual(target_command, mocks[1].call_args[0][0])
 
     @mock.patch('compose_flow.shell.execute')
-    @mock.patch('compose_flow.commands.subcommands.pod.Pod.switch_kube_context')
+    @mock.patch('compose_flow.commands.subcommands.pod.Pod.switch_rancher_context')
     def test_exec_pod_without_specified_container(self, *mocks):
         """
         Basic test to ensure the command runs as expected
         """
         argv = shlex.split(
-            '-e test pod exec sample-namespace generic-workers /bin/bash'
+            '-e test pod exec generic-workers /bin/bash'
         )
         workflow = Workflow(argv=argv)
 
@@ -72,7 +72,7 @@ class PodTestCase(BaseTestCase):
         workflow.run()
 
         target_command = (
-            'rancher kubectl -n sample-namespace exec -it generic-workers-6c744b8fb8-7sjb8  -- /bin/bash'
+            f'rancher kubectl -n {workflow.project_name} exec -it generic-workers-6c744b8fb8-7sjb8  -- /bin/bash'
         )
 
         self.assertEqual(target_command, mocks[1].call_args[0][0])

--- a/src/tests/test_pod.py
+++ b/src/tests/test_pod.py
@@ -29,7 +29,7 @@ class PodTestCase(BaseTestCase):
         return raw_data
 
     @mock.patch('compose_flow.shell.execute')
-    @mock.patch('compose_flow.commands.subcommands.pod.Pod.switch_kube_context')
+    @mock.patch('compose_flow.commands.subcommands.pod.Pod.switch_rancher_context')
     def test_exec_pod_with_specified_container_and_index(self, *mocks):
         """
         Basic test to ensure the command runs as expected

--- a/src/tests/test_pod.py
+++ b/src/tests/test_pod.py
@@ -57,7 +57,7 @@ class PodTestCase(BaseTestCase):
     @mock.patch('compose_flow.commands.subcommands.pod.Pod.switch_rancher_context')
     def test_exec_pod_without_specified_container(self, *mocks):
         """
-        Basic test to ensure the command runs as expected
+        Test that the command works when no container is specified
         """
         argv = shlex.split(
             '-e test pod exec generic-workers /bin/bash'
@@ -81,7 +81,7 @@ class PodTestCase(BaseTestCase):
     @mock.patch('compose_flow.commands.subcommands.pod.Pod.switch_rancher_context')
     def test_exec_pod_with_specified_namespace(self, *mocks):
         """
-        Basic test to ensure the command runs as expected
+        Test that we can override the namespace with --namespace.
         """
         argv = shlex.split(
             '-e test pod exec --namespace foobar generic-workers /bin/bash'

--- a/src/tests/test_pod.py
+++ b/src/tests/test_pod.py
@@ -76,3 +76,27 @@ class PodTestCase(BaseTestCase):
         )
 
         self.assertEqual(target_command, mocks[1].call_args[0][0])
+
+    @mock.patch('compose_flow.shell.execute')
+    @mock.patch('compose_flow.commands.subcommands.pod.Pod.switch_rancher_context')
+    def test_exec_pod_with_specified_namespace(self, *mocks):
+        """
+        Basic test to ensure the command runs as expected
+        """
+        argv = shlex.split(
+            '-e test pod exec --namespace foobar generic-workers /bin/bash'
+        )
+        workflow = Workflow(argv=argv)
+
+        pod = workflow.subcommand
+
+        pod.list_pods = mock.MagicMock()
+        pod.list_pods.return_value = self._get_mock_pod_list_raw()
+
+        workflow.run()
+
+        target_command = (
+            f'rancher kubectl -n foobar exec -it generic-workers-6c744b8fb8-7sjb8  -- /bin/bash'
+        )
+
+        self.assertEqual(target_command, mocks[1].call_args[0][0])


### PR DESCRIPTION
- switch rancher context instead of kube context
- use workflow project_name as namespace param
- improve error handling when a pod cannot be found
- allow escape hatch namespace override with `--namespace`