### PR TITLE
Add logic to allow editing of runtime variables without defining them

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@ def customPublishTask = {
 def publishWhen = { env.TAG_NAME }
 
 openslatePipeline {
-    mentions = '@roberto <@marcusian>'
+    mentions = '@roberto <@UB22LFDEJ>'
     deployEnv = 'prod'
     lint = true
     test = true

--- a/src/tests/test_env.py
+++ b/src/tests/test_env.py
@@ -1,8 +1,9 @@
+import os
 import shlex
 from unittest import TestCase, mock
 
-from compose_flow import utils
-from compose_flow.commands.subcommands.env import Env
+from compose_flow import errors
+from compose_flow.commands.subcommands.env import Env, RUNTIME_PLACEHOLDER
 from compose_flow.commands import Workflow
 
 from tests import BaseTestCase
@@ -122,3 +123,49 @@ class EnvTestCase(BaseTestCase):
         self.assertEqual(
             ['BAR', 'DOCKER_IMAGE', 'FOO', 'VERSION'], sorted(env._persistable_keys)
         )
+
+    @mock.patch('compose_flow.commands.subcommands.env.get_backend')
+    def test_load_runtime(self, *mocks):
+        """
+        Ensures that runtime variables are able to be viewed/edited without being set
+        """
+        version = '1.2.3'
+        docker_image = 'foo:bar'
+
+        bar_env_val = 'bar'
+        os.environ['BAR'] = bar_env_val
+
+        get_backend_mock = mocks[0]
+        get_backend_mock.return_value.read.return_value = (
+            f"FOO={RUNTIME_PLACEHOLDER}\nBAR={RUNTIME_PLACEHOLDER}\nVERSION={version}\nDOCKER_IMAGE={docker_image}"
+        )
+
+        command = shlex.split('-e dev env cat')
+        flow = Workflow(argv=command)
+
+        flow.run()
+
+        env = flow.subcommand
+
+        self.assertEqual(RUNTIME_PLACEHOLDER, env.data['FOO'])
+        self.assertEqual(bar_env_val, env.data['BAR'])
+
+    @mock.patch('compose_flow.commands.subcommands.env.get_backend')
+    def test_missing_runtime_error(self, *mocks):
+        """
+        Ensures that runtime variables must be set to run any compose commands
+        """
+        version = '1.2.3'
+        docker_image = 'foo:bar'
+
+        get_backend_mock = mocks[0]
+        get_backend_mock.return_value.read.return_value = (
+            f"FOO={RUNTIME_PLACEHOLDER}\nVERSION={version}\nDOCKER_IMAGE={docker_image}"
+        )
+
+        command = shlex.split('-e dev compose config')
+        flow = Workflow(argv=command)
+
+        assert os.environ.get('FOO') is None
+        with self.assertRaises(errors.RuntimeEnvError):
+            flow.profile.data['services']


### PR DESCRIPTION
~Need to test this locally~

Tested this locally, it seems to work as expected: when a variable is not defined it can be edited as `runtime://` but it throws an error if you try to run `compose` or `deploy` without defining a variable

Resolves openslate/openslate#2433