### PR TITLE
Add namespace to NoSuchConfig error

### DIFF
--- a/src/compose_flow/kube/mixins.py
+++ b/src/compose_flow/kube/mixins.py
@@ -111,7 +111,7 @@ class KubeMixIn(object):
 
             if f'secrets "{self.secret_name}" not found' in message:
                 self.secret_exists = False
-                raise errors.NoSuchConfig(f'secret name={self.secret_name} not found')
+                raise errors.NoSuchConfig(f'secret name={self.secret_name} in namespace={self.namespace} not found')
 
             raise
 


### PR DESCRIPTION
Spent too much time trying to figure out an error on the cli, which was due to the cf env not being defined.  The namespace would have helped and given me better direction to fix the problem.