### PR TITLE
Project based compose flow file

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -12,6 +12,7 @@ tag-version = "*"
 tabulate = "*"
 docker-compose = "*"
 semver = "*"
+influxstats = "==0.0.10rc5"
 
 [dev-packages]
 black = "==19.3b0"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "3cc9f7e3cd90e6e86ab57c04e34dd03f6679be86f6d2a073094aea8dcdecf96c"
+            "sha256": "673983d4efbaf068648eb5c0a1cf310e1f27659ed40f66141068a1eec4241606"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -16,19 +16,13 @@
         ]
     },
     "default": {
-        "asn1crypto": {
-            "hashes": [
-                "sha256:0b199f211ae690df3db4fd6c1c4ff976497fb1da689193e368eedbadc53d9292",
-                "sha256:bca90060bd995c3f62c4433168eab407e44bdbdb567b3f3a396a676c1a4c4a3f"
-            ],
-            "version": "==1.0.1"
-        },
         "bcrypt": {
             "hashes": [
                 "sha256:0258f143f3de96b7c14f762c770f5fc56ccd72f8a1857a451c1cd9a655d9ac89",
                 "sha256:0b0069c752ec14172c5f78208f1863d7ad6755a6fae6fe76ec2c80d13be41e42",
                 "sha256:19a4b72a6ae5bb467fea018b825f0a7d917789bcfe893e53f15c92805d187294",
                 "sha256:5432dd7b34107ae8ed6c10a71b4397f1c853bd39a4d6ffa7e35f40584cffd161",
+                "sha256:6305557019906466fc42dbc53b46da004e72fd7a551c044a827e572c82191752",
                 "sha256:69361315039878c0680be456640f8705d76cb4a3a3fe1e057e0f261b74be4b31",
                 "sha256:6fe49a60b25b584e2f4ef175b29d3a83ba63b3a4df1b4c0605b826668d1b6be5",
                 "sha256:74a015102e877d0ccd02cdeaa18b32aa7273746914a6c5d0456dd442cb65b99c",
@@ -39,6 +33,7 @@
                 "sha256:a595c12c618119255c90deb4b046e1ca3bcfad64667c43d1166f2b04bc72db09",
                 "sha256:c9457fa5c121e94a58d6505cadca8bed1c64444b83b3204928a866ca2e599105",
                 "sha256:cb93f6b2ab0f6853550b74e051d297c27a638719753eb9ff66d1e4072be67133",
+                "sha256:ce4e4f0deb51d38b1611a27f330426154f2980e66582dc5f438aad38b5f24fc1",
                 "sha256:d7bdc26475679dd073ba0ed2766445bb5b20ca4793ca0db32b399dccc6bc84b7",
                 "sha256:ff032765bb8716d9387fd5376d987a937254b0619eff0972779515b5c98820bc"
             ],
@@ -46,11 +41,11 @@
         },
         "boltons": {
             "hashes": [
-                "sha256:7aa10b0f5b015678458a7d0422961fc0c7e823c05e644094c0e564931ce0b0df",
-                "sha256:c32b2d121331a9bc7c220050d4273f3aa359b7569cb4794188e71524603113dc"
+                "sha256:7b3344098aa0d593e1a04cd290f61310d5aefc66aeb1e07262d5afdabdb88a67",
+                "sha256:8f8ed28b99b99074144482e69c0c566c56888ac1c2f6216e74b60b3ac2bec911"
             ],
             "index": "pypi",
-            "version": "==19.1.0"
+            "version": "==19.3.0"
         },
         "cached-property": {
             "hashes": [
@@ -68,36 +63,41 @@
         },
         "cffi": {
             "hashes": [
-                "sha256:041c81822e9f84b1d9c401182e174996f0bae9991f33725d059b771744290774",
-                "sha256:046ef9a22f5d3eed06334d01b1e836977eeef500d9b78e9ef693f9380ad0b83d",
-                "sha256:066bc4c7895c91812eff46f4b1c285220947d4aa46fa0a2651ff85f2afae9c90",
-                "sha256:066c7ff148ae33040c01058662d6752fd73fbc8e64787229ea8498c7d7f4041b",
-                "sha256:2444d0c61f03dcd26dbf7600cf64354376ee579acad77aef459e34efcb438c63",
-                "sha256:300832850b8f7967e278870c5d51e3819b9aad8f0a2c8dbe39ab11f119237f45",
-                "sha256:34c77afe85b6b9e967bd8154e3855e847b70ca42043db6ad17f26899a3df1b25",
-                "sha256:46de5fa00f7ac09f020729148ff632819649b3e05a007d286242c4882f7b1dc3",
-                "sha256:4aa8ee7ba27c472d429b980c51e714a24f47ca296d53f4d7868075b175866f4b",
-                "sha256:4d0004eb4351e35ed950c14c11e734182591465a33e960a4ab5e8d4f04d72647",
-                "sha256:4e3d3f31a1e202b0f5a35ba3bc4eb41e2fc2b11c1eff38b362de710bcffb5016",
-                "sha256:50bec6d35e6b1aaeb17f7c4e2b9374ebf95a8975d57863546fa83e8d31bdb8c4",
-                "sha256:55cad9a6df1e2a1d62063f79d0881a414a906a6962bc160ac968cc03ed3efcfb",
-                "sha256:5662ad4e4e84f1eaa8efce5da695c5d2e229c563f9d5ce5b0113f71321bcf753",
-                "sha256:59b4dc008f98fc6ee2bb4fd7fc786a8d70000d058c2bbe2698275bc53a8d3fa7",
-                "sha256:73e1ffefe05e4ccd7bcea61af76f36077b914f92b76f95ccf00b0c1b9186f3f9",
-                "sha256:a1f0fd46eba2d71ce1589f7e50a9e2ffaeb739fb2c11e8192aa2b45d5f6cc41f",
-                "sha256:a2e85dc204556657661051ff4bab75a84e968669765c8a2cd425918699c3d0e8",
-                "sha256:a5457d47dfff24882a21492e5815f891c0ca35fefae8aa742c6c263dac16ef1f",
-                "sha256:a8dccd61d52a8dae4a825cdbb7735da530179fea472903eb871a5513b5abbfdc",
-                "sha256:ae61af521ed676cf16ae94f30fe202781a38d7178b6b4ab622e4eec8cefaff42",
-                "sha256:b012a5edb48288f77a63dba0840c92d0504aa215612da4541b7b42d849bc83a3",
-                "sha256:d2c5cfa536227f57f97c92ac30c8109688ace8fa4ac086d19d0af47d134e2909",
-                "sha256:d42b5796e20aacc9d15e66befb7a345454eef794fdb0737d1af593447c6c8f45",
-                "sha256:dee54f5d30d775f525894d67b1495625dd9322945e7fee00731952e0368ff42d",
-                "sha256:e070535507bd6aa07124258171be2ee8dfc19119c28ca94c9dfb7efd23564512",
-                "sha256:e1ff2748c84d97b065cc95429814cdba39bcbd77c9c85c89344b317dc0d9cbff",
-                "sha256:ed851c75d1e0e043cbf5ca9a8e1b13c4c90f3fbd863dacb01c0808e2b5204201"
+                "sha256:0b49274afc941c626b605fb59b59c3485c17dc776dc3cc7cc14aca74cc19cc42",
+                "sha256:0e3ea92942cb1168e38c05c1d56b0527ce31f1a370f6117f1d490b8dcd6b3a04",
+                "sha256:135f69aecbf4517d5b3d6429207b2dff49c876be724ac0c8bf8e1ea99df3d7e5",
+                "sha256:19db0cdd6e516f13329cba4903368bff9bb5a9331d3410b1b448daaadc495e54",
+                "sha256:2781e9ad0e9d47173c0093321bb5435a9dfae0ed6a762aabafa13108f5f7b2ba",
+                "sha256:291f7c42e21d72144bb1c1b2e825ec60f46d0a7468f5346841860454c7aa8f57",
+                "sha256:2c5e309ec482556397cb21ede0350c5e82f0eb2621de04b2633588d118da4396",
+                "sha256:2e9c80a8c3344a92cb04661115898a9129c074f7ab82011ef4b612f645939f12",
+                "sha256:32a262e2b90ffcfdd97c7a5e24a6012a43c61f1f5a57789ad80af1d26c6acd97",
+                "sha256:3c9fff570f13480b201e9ab69453108f6d98244a7f495e91b6c654a47486ba43",
+                "sha256:415bdc7ca8c1c634a6d7163d43fb0ea885a07e9618a64bda407e04b04333b7db",
+                "sha256:42194f54c11abc8583417a7cf4eaff544ce0de8187abaf5d29029c91b1725ad3",
+                "sha256:4424e42199e86b21fc4db83bd76909a6fc2a2aefb352cb5414833c030f6ed71b",
+                "sha256:4a43c91840bda5f55249413037b7a9b79c90b1184ed504883b72c4df70778579",
+                "sha256:599a1e8ff057ac530c9ad1778293c665cb81a791421f46922d80a86473c13346",
+                "sha256:5c4fae4e9cdd18c82ba3a134be256e98dc0596af1e7285a3d2602c97dcfa5159",
+                "sha256:5ecfa867dea6fabe2a58f03ac9186ea64da1386af2159196da51c4904e11d652",
+                "sha256:62f2578358d3a92e4ab2d830cd1c2049c9c0d0e6d3c58322993cc341bdeac22e",
+                "sha256:6471a82d5abea994e38d2c2abc77164b4f7fbaaf80261cb98394d5793f11b12a",
+                "sha256:6d4f18483d040e18546108eb13b1dfa1000a089bcf8529e30346116ea6240506",
+                "sha256:71a608532ab3bd26223c8d841dde43f3516aa5d2bf37b50ac410bb5e99053e8f",
+                "sha256:74a1d8c85fb6ff0b30fbfa8ad0ac23cd601a138f7509dc617ebc65ef305bb98d",
+                "sha256:7b93a885bb13073afb0aa73ad82059a4c41f4b7d8eb8368980448b52d4c7dc2c",
+                "sha256:7d4751da932caaec419d514eaa4215eaf14b612cff66398dd51129ac22680b20",
+                "sha256:7f627141a26b551bdebbc4855c1157feeef18241b4b8366ed22a5c7d672ef858",
+                "sha256:8169cf44dd8f9071b2b9248c35fc35e8677451c52f795daa2bb4643f32a540bc",
+                "sha256:aa00d66c0fab27373ae44ae26a66a9e43ff2a678bf63a9c7c1a9a4d61172827a",
+                "sha256:ccb032fda0873254380aa2bfad2582aedc2959186cce61e3a17abc1a55ff89c3",
+                "sha256:d754f39e0d1603b5b24a7f8484b22d2904fa551fe865fd0d4c3332f078d20d4e",
+                "sha256:d75c461e20e29afc0aee7172a0950157c704ff0dd51613506bd7d82b718e7410",
+                "sha256:dcd65317dd15bc0451f3e01c80da2216a31916bdcffd6221ca1202d96584aa25",
+                "sha256:e570d3ab32e2c2861c4ebe6ffcad6a8abf9347432a37608fe1fbd157b3f0036b",
+                "sha256:fd43a88e045cf992ed09fa724b5315b790525f2676883a6ea64e3263bae6549d"
             ],
-            "version": "==1.12.3"
+            "version": "==1.13.2"
         },
         "chardet": {
             "hashes": [
@@ -108,24 +108,29 @@
         },
         "cryptography": {
             "hashes": [
-                "sha256:24b61e5fcb506424d3ec4e18bca995833839bf13c59fc43e530e488f28d46b8c",
-                "sha256:25dd1581a183e9e7a806fe0543f485103232f940fcfc301db65e630512cce643",
-                "sha256:3452bba7c21c69f2df772762be0066c7ed5dc65df494a1d53a58b683a83e1216",
-                "sha256:41a0be220dd1ed9e998f5891948306eb8c812b512dc398e5a01846d855050799",
-                "sha256:5751d8a11b956fbfa314f6553d186b94aa70fdb03d8a4d4f1c82dcacf0cbe28a",
-                "sha256:5f61c7d749048fa6e3322258b4263463bfccefecb0dd731b6561cb617a1d9bb9",
-                "sha256:72e24c521fa2106f19623a3851e9f89ddfdeb9ac63871c7643790f872a305dfc",
-                "sha256:7b97ae6ef5cba2e3bb14256625423413d5ce8d1abb91d4f29b6d1a081da765f8",
-                "sha256:961e886d8a3590fd2c723cf07be14e2a91cf53c25f02435c04d39e90780e3b53",
-                "sha256:96d8473848e984184b6728e2c9d391482008646276c3ff084a1bd89e15ff53a1",
-                "sha256:ae536da50c7ad1e002c3eee101871d93abdc90d9c5f651818450a0d3af718609",
-                "sha256:b0db0cecf396033abb4a93c95d1602f268b3a68bb0a9cc06a7cff587bb9a7292",
-                "sha256:cfee9164954c186b191b91d4193989ca994703b2fff406f71cf454a2d3c7327e",
-                "sha256:e6347742ac8f35ded4a46ff835c60e68c22a536a8ae5c4422966d06946b6d4c6",
-                "sha256:f27d93f0139a3c056172ebb5d4f9056e770fdf0206c2f422ff2ebbad142e09ed",
-                "sha256:f57b76e46a58b63d1c6375017f4564a28f19a5ca912691fd2e4261b3414b618d"
+                "sha256:02079a6addc7b5140ba0825f542c0869ff4df9a69c360e339ecead5baefa843c",
+                "sha256:1df22371fbf2004c6f64e927668734070a8953362cd8370ddd336774d6743595",
+                "sha256:369d2346db5934345787451504853ad9d342d7f721ae82d098083e1f49a582ad",
+                "sha256:3cda1f0ed8747339bbdf71b9f38ca74c7b592f24f65cdb3ab3765e4b02871651",
+                "sha256:44ff04138935882fef7c686878e1c8fd80a723161ad6a98da31e14b7553170c2",
+                "sha256:4b1030728872c59687badcca1e225a9103440e467c17d6d1730ab3d2d64bfeff",
+                "sha256:58363dbd966afb4f89b3b11dfb8ff200058fbc3b947507675c19ceb46104b48d",
+                "sha256:6ec280fb24d27e3d97aa731e16207d58bd8ae94ef6eab97249a2afe4ba643d42",
+                "sha256:7270a6c29199adc1297776937a05b59720e8a782531f1f122f2eb8467f9aab4d",
+                "sha256:73fd30c57fa2d0a1d7a49c561c40c2f79c7d6c374cc7750e9ac7c99176f6428e",
+                "sha256:7f09806ed4fbea8f51585231ba742b58cbcfbfe823ea197d8c89a5e433c7e912",
+                "sha256:90df0cc93e1f8d2fba8365fb59a858f51a11a394d64dbf3ef844f783844cc793",
+                "sha256:971221ed40f058f5662a604bd1ae6e4521d84e6cad0b7b170564cc34169c8f13",
+                "sha256:a518c153a2b5ed6b8cc03f7ae79d5ffad7315ad4569b2d5333a13c38d64bd8d7",
+                "sha256:b0de590a8b0979649ebeef8bb9f54394d3a41f66c5584fff4220901739b6b2f0",
+                "sha256:b43f53f29816ba1db8525f006fa6f49292e9b029554b3eb56a189a70f2a40879",
+                "sha256:d31402aad60ed889c7e57934a03477b572a03af7794fa8fb1780f21ea8f6551f",
+                "sha256:de96157ec73458a7f14e3d26f17f8128c959084931e8997b9e655a39c8fde9f9",
+                "sha256:df6b4dca2e11865e6cfbfb708e800efb18370f5a46fd601d3755bc7f85b3a8a2",
+                "sha256:ecadccc7ba52193963c0475ac9f6fa28ac01e01349a2ca48509667ef41ffd2cf",
+                "sha256:fb81c17e0ebe3358486cd8cc3ad78adbae58af12fc2bf2bc0bb84e8090fa5ce8"
             ],
-            "version": "==2.7"
+            "version": "==2.8"
         },
         "docker": {
             "extras": [
@@ -170,6 +175,13 @@
                 "sha256:684a38a6f903c1d71d6d5fac066b58d7768af4de2b832e426ec79c30daa94a16"
             ],
             "version": "==2.7"
+        },
+        "influxstats": {
+            "hashes": [
+                "sha256:71cf1baa7062832d94aaa7a6ef41f0ed653f49c2c79af982625b17170750d9af"
+            ],
+            "index": "pypi",
+            "version": "==0.0.10rc5"
         },
         "jinja2": {
             "hashes": [
@@ -243,6 +255,7 @@
                 "sha256:30f36a9c70450c7878053fa1344aca0145fd47d845270b43a7ee9192a051bf39",
                 "sha256:37aa336a317209f1bb099ad177fef0da45be36a2aa664507c5d72015f956c310",
                 "sha256:4943decfc5b905748f0756fdd99d4f9498d7064815c4cf3643820c9028b711d1",
+                "sha256:53126cd91356342dcae7e209f840212a58dcf1177ad52c1d938d428eebc9fee5",
                 "sha256:57ef38a65056e7800859e5ba9e6091053cd06e1038983016effaffe0efcd594a",
                 "sha256:5bd61e9b44c543016ce1f6aef48606280e45f892a928ca7068fba30021e9b786",
                 "sha256:6482d3017a0c0327a49dddc8bd1074cc730d45db2ccb09c3bac1f8f32d1eb61b",
@@ -251,6 +264,7 @@
                 "sha256:a39f54ccbcd2757d1d63b0ec00a00980c0b382c62865b61a505163943624ab20",
                 "sha256:aabb0c5232910a20eec8563503c153a8e78bbf5459490c49ab31f6adf3f3a415",
                 "sha256:bd4ecb473a96ad0f90c20acba4f0bf0df91a4e03a1f4dd6a4bdc9ca75aa3a715",
+                "sha256:bf459128feb543cfca16a95f8da31e2e65e4c5257d2f3dfa8c0c1031139c9c92",
                 "sha256:e2da3c13307eac601f3de04887624939aca8ee3c9488a0bb0eca4fb9401fc6b1",
                 "sha256:f67814c38162f4deb31f68d590771a29d5ae3b1bd64b75cf232308e5c74777e0"
             ],
@@ -282,11 +296,11 @@
         },
         "semver": {
             "hashes": [
-                "sha256:41c9aa26c67dc16c54be13074c352ab666bce1fa219c7110e8f03374cd4206b0",
-                "sha256:5b09010a66d9a3837211bb7ae5a20d10ba88f8cb49e92cb139a69ef90d5060d8"
+                "sha256:aa1c6be3bf23e346e00c509a7ee87735a7e0fd6b404cf066037cfeab2c770320",
+                "sha256:ed1edeaa0c27f68feb74f09f715077fd07b728446dc2bb7fc470fc0f737873a0"
             ],
             "index": "pypi",
-            "version": "==2.8.1"
+            "version": "==2.9.0"
         },
         "sh": {
             "hashes": [
@@ -298,10 +312,17 @@
         },
         "six": {
             "hashes": [
-                "sha256:3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c",
-                "sha256:d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"
+                "sha256:1f1b7d42e254082a9db6279deae68afb421ceba6158efa6131de7b3003ee93fd",
+                "sha256:30f610279e8b2578cab6db20741130331735c781b56053c59c4076da27f06b66"
             ],
-            "version": "==1.12.0"
+            "version": "==1.13.0"
+        },
+        "statsd": {
+            "hashes": [
+                "sha256:c610fb80347fca0ef62666d241bce64184bd7cc1efe582f9690e045c25535eaa",
+                "sha256:e3e6db4c246f7c59003e51c9720a51a7f39a396541cb9b147ff4b14d15b5dd1f"
+            ],
+            "version": "==3.3.0"
         },
         "tabulate": {
             "hashes": [
@@ -355,17 +376,17 @@
         },
         "astroid": {
             "hashes": [
-                "sha256:98c665ad84d10b18318c5ab7c3d203fe11714cbad2a4aef4f44651f415392754",
-                "sha256:b7546ffdedbf7abcfbff93cd1de9e9980b1ef744852689decc5aeada324238c6"
+                "sha256:71ea07f44df9568a75d0f354c49143a4575d90645e9fead6dfb52c26a85ed13a",
+                "sha256:840947ebfa8b58f318d42301cf8c0a20fd794a33b61cc4638e28e9e61ba32f42"
             ],
-            "version": "==2.3.1"
+            "version": "==2.3.3"
         },
         "attrs": {
             "hashes": [
-                "sha256:ec20e7a4825331c1b5ebf261d111e16fa9612c1f7a5e1f884f12bd53a664dfd2",
-                "sha256:f913492e1663d3c36f502e5e9ba6cd13cf19d7fab50aa13239e420fef95e1396"
+                "sha256:08a96c641c3a74e44eb59afb61a24f2cb9f4d7188748e76ba4bb5edfa3cb7d1c",
+                "sha256:f7b7ce16570fe9965acd6d30101a28f62fb4a7f9e926b3bbc9b61f8b04247e72"
             ],
-            "version": "==19.2.0"
+            "version": "==19.3.0"
         },
         "black": {
             "hashes": [
@@ -427,26 +448,29 @@
         },
         "lazy-object-proxy": {
             "hashes": [
-                "sha256:02b260c8deb80db09325b99edf62ae344ce9bc64d68b7a634410b8e9a568edbf",
-                "sha256:18f9c401083a4ba6e162355873f906315332ea7035803d0fd8166051e3d402e3",
-                "sha256:1f2c6209a8917c525c1e2b55a716135ca4658a3042b5122d4e3413a4030c26ce",
-                "sha256:2f06d97f0ca0f414f6b707c974aaf8829c2292c1c497642f63824119d770226f",
-                "sha256:616c94f8176808f4018b39f9638080ed86f96b55370b5a9463b2ee5c926f6c5f",
-                "sha256:63b91e30ef47ef68a30f0c3c278fbfe9822319c15f34b7538a829515b84ca2a0",
-                "sha256:77b454f03860b844f758c5d5c6e5f18d27de899a3db367f4af06bec2e6013a8e",
-                "sha256:83fe27ba321e4cfac466178606147d3c0aa18e8087507caec78ed5a966a64905",
-                "sha256:84742532d39f72df959d237912344d8a1764c2d03fe58beba96a87bfa11a76d8",
-                "sha256:874ebf3caaf55a020aeb08acead813baf5a305927a71ce88c9377970fe7ad3c2",
-                "sha256:9f5caf2c7436d44f3cec97c2fa7791f8a675170badbfa86e1992ca1b84c37009",
-                "sha256:a0c8758d01fcdfe7ae8e4b4017b13552efa7f1197dd7358dc9da0576f9d0328a",
-                "sha256:a4def978d9d28cda2d960c279318d46b327632686d82b4917516c36d4c274512",
-                "sha256:ad4f4be843dace866af5fc142509e9b9817ca0c59342fdb176ab6ad552c927f5",
-                "sha256:ae33dd198f772f714420c5ab698ff05ff900150486c648d29951e9c70694338e",
-                "sha256:b4a2b782b8a8c5522ad35c93e04d60e2ba7f7dcb9271ec8e8c3e08239be6c7b4",
-                "sha256:c462eb33f6abca3b34cdedbe84d761f31a60b814e173b98ede3c81bb48967c4f",
-                "sha256:fd135b8d35dfdcdb984828c84d695937e58cc5f49e1c854eb311c4d6aa03f4f1"
+                "sha256:0c4b206227a8097f05c4dbdd323c50edf81f15db3b8dc064d08c62d37e1a504d",
+                "sha256:194d092e6f246b906e8f70884e620e459fc54db3259e60cf69a4d66c3fda3449",
+                "sha256:1be7e4c9f96948003609aa6c974ae59830a6baecc5376c25c92d7d697e684c08",
+                "sha256:4677f594e474c91da97f489fea5b7daa17b5517190899cf213697e48d3902f5a",
+                "sha256:48dab84ebd4831077b150572aec802f303117c8cc5c871e182447281ebf3ac50",
+                "sha256:5541cada25cd173702dbd99f8e22434105456314462326f06dba3e180f203dfd",
+                "sha256:59f79fef100b09564bc2df42ea2d8d21a64fdcda64979c0fa3db7bdaabaf6239",
+                "sha256:8d859b89baf8ef7f8bc6b00aa20316483d67f0b1cbf422f5b4dc56701c8f2ffb",
+                "sha256:9254f4358b9b541e3441b007a0ea0764b9d056afdeafc1a5569eee1cc6c1b9ea",
+                "sha256:9651375199045a358eb6741df3e02a651e0330be090b3bc79f6d0de31a80ec3e",
+                "sha256:97bb5884f6f1cdce0099f86b907aa41c970c3c672ac8b9c8352789e103cf3156",
+                "sha256:9b15f3f4c0f35727d3a0fba4b770b3c4ebbb1fa907dbcc046a1d2799f3edd142",
+                "sha256:a2238e9d1bb71a56cd710611a1614d1194dc10a175c1e08d75e1a7bcc250d442",
+                "sha256:a6ae12d08c0bf9909ce12385803a543bfe99b95fe01e752536a60af2b7797c62",
+                "sha256:ca0a928a3ddbc5725be2dd1cf895ec0a254798915fb3a36af0964a0a4149e3db",
+                "sha256:cb2c7c57005a6804ab66f106ceb8482da55f5314b7fcb06551db1edae4ad1531",
+                "sha256:d74bb8693bf9cf75ac3b47a54d716bbb1a92648d5f781fc799347cfc95952383",
+                "sha256:d945239a5639b3ff35b70a88c5f2f491913eb94871780ebfabb2568bd58afc5a",
+                "sha256:eba7011090323c1dadf18b3b689845fd96a61ba0a1dfbd7f24b921398affc357",
+                "sha256:efa1909120ce98bbb3777e8b6f92237f5d5c8ea6758efea36a473e1d38f7d3e4",
+                "sha256:f3900e8a5de27447acbf900b4750b0ddfd7ec1ea7fbaf11dfa911141bc522af0"
             ],
-            "version": "==1.4.2"
+            "version": "==1.4.3"
         },
         "mccabe": {
             "hashes": [
@@ -523,11 +547,11 @@
         },
         "pylint": {
             "hashes": [
-                "sha256:7edbae11476c2182708063ac387a8f97c760d9cfe36a5ede0ca996f90cf346c8",
-                "sha256:844ce067788028c1a35086a5c66bc5e599ddd851841c41d6ee1623b36774d9f2"
+                "sha256:7b76045426c650d2b0f02fc47c14d7934d17898779da95288a74c2a7ec440702",
+                "sha256:856476331f3e26598017290fd65bebe81c960e806776f324093a46b76fb2d1c0"
             ],
             "index": "pypi",
-            "version": "==2.4.2"
+            "version": "==2.4.3"
         },
         "pyyaml": {
             "hashes": [
@@ -569,10 +593,10 @@
         },
         "six": {
             "hashes": [
-                "sha256:3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c",
-                "sha256:d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"
+                "sha256:1f1b7d42e254082a9db6279deae68afb421ceba6158efa6131de7b3003ee93fd",
+                "sha256:30f610279e8b2578cab6db20741130331735c781b56053c59c4076da27f06b66"
             ],
-            "version": "==1.12.0"
+            "version": "==1.13.0"
         },
         "snowballstemmer": {
             "hashes": [
@@ -590,10 +614,10 @@
         },
         "tqdm": {
             "hashes": [
-                "sha256:abc25d0ce2397d070ef07d8c7e706aede7920da163c64997585d42d3537ece3d",
-                "sha256:dd3fcca8488bb1d416aa7469d2f277902f26260c45aa86b667b074cd44b3b115"
+                "sha256:94d2a64582150f503a294b3b8889413e7e56d6043473d6a5672d46185b043902",
+                "sha256:fca09992116d6dc3ad9789cf601a254081eb40d5c14c1863ab6cd10e15c2cb26"
             ],
-            "version": "==4.36.1"
+            "version": "==4.37.0"
         },
         "twine": {
             "hashes": [
@@ -605,20 +629,25 @@
         },
         "typed-ast": {
             "hashes": [
+                "sha256:1170afa46a3799e18b4c977777ce137bb53c7485379d9706af8a59f2ea1aa161",
                 "sha256:18511a0b3e7922276346bcb47e2ef9f38fb90fd31cb9223eed42c85d1312344e",
                 "sha256:262c247a82d005e43b5b7f69aff746370538e176131c32dda9cb0f324d27141e",
                 "sha256:2b907eb046d049bcd9892e3076c7a6456c93a25bebfe554e931620c90e6a25b0",
                 "sha256:354c16e5babd09f5cb0ee000d54cfa38401d8b8891eefa878ac772f827181a3c",
+                "sha256:48e5b1e71f25cfdef98b013263a88d7145879fbb2d5185f2a0c79fa7ebbeae47",
                 "sha256:4e0b70c6fc4d010f8107726af5fd37921b666f5b31d9331f0bd24ad9a088e631",
                 "sha256:630968c5cdee51a11c05a30453f8cd65e0cc1d2ad0d9192819df9978984529f4",
                 "sha256:66480f95b8167c9c5c5c87f32cf437d585937970f3fc24386f313a4c97b44e34",
                 "sha256:71211d26ffd12d63a83e079ff258ac9d56a1376a25bc80b1cdcdf601b855b90b",
+                "sha256:7954560051331d003b4e2b3eb822d9dd2e376fa4f6d98fee32f452f52dd6ebb2",
+                "sha256:838997f4310012cf2e1ad3803bce2f3402e9ffb71ded61b5ee22617b3a7f6b6e",
                 "sha256:95bd11af7eafc16e829af2d3df510cecfd4387f6453355188342c3e79a2ec87a",
                 "sha256:bc6c7d3fa1325a0c6613512a093bc2a2a15aeec350451cbdf9e1d4bffe3e3233",
                 "sha256:cc34a6f5b426748a507dd5d1de4c1978f2eb5626d51326e43280941206c209e1",
                 "sha256:d755f03c1e4a51e9b24d899561fec4ccaf51f210d52abdf8c07ee2849b212a36",
                 "sha256:d7c45933b1bdfaf9f36c579671fec15d25b06c8398f113dab64c18ed1adda01d",
                 "sha256:d896919306dd0aa22d0132f62a1b78d11aaf4c9fc5b3410d3c666b818191630a",
+                "sha256:fdc1c9bbf79510b76408840e009ed65958feba92a88833cdceecff93ae8fff66",
                 "sha256:ffde2fbfad571af120fcbfbbc61c72469e72f550d676c3342492a9dfdefb8f12"
             ],
             "markers": "implementation_name == 'cpython' and python_version < '3.8'",

--- a/compose/compose-flow.yml
+++ b/compose/compose-flow.yml
@@ -42,7 +42,7 @@ tasks:
     command: compose-flow compose run --rm app /bin/bash -c 'pylama ./src'
 
   jenkinslint:
-    command: compose-flow compose run -u root:docker --rm app /bin/bash -c 'black --target-version py36 --target-version py37 --target-version py38 --check . && pylama -r results/pylama.log -f pylint || /bin/true'
+    command: compose-flow compose run -u root:docker --rm app /bin/bash -c 'black --target-version py36 --target-version py37 --target-version py38 --check . && (pylama -r results/pylama.log -f pylint setup.py ./scripts ./src || /bin/true)'
 
   jenkinstest:
     command: compose-flow compose run -u root:docker --rm app /bin/bash -c 'nosetests -v ./src --with-xunit --xunit-file=results/report.xml || /bin/true'

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,3 @@
+[options]
+setup_requires =
+  setuptools_scm

--- a/setup.py
+++ b/setup.py
@@ -15,17 +15,43 @@ def readme():
 def get_required_packages():
     """
     Returns the packages used for install_requires
+
     This used to pin down every package in Pipfile.lock to the version, but that, in turn, broke
     downstream projects because it was way too strict.
+
     Now, this simply grabs all the items listed in the `Pipfile` `[packages]` section without version
     pinning
     """
-    install_requires = []
-
-    config = configparser.ConfigParser()
+    config = configparser.ConfigParser(strict=False)
     config.read("Pipfile")
 
-    install_requires = sorted([x for x in config["packages"]])
+    # when the Pipfile specifies a package, constrain it to that version
+    install_requires = []
+    for package, version in config["packages"].items():
+        full_package = package
+        package_version = None
+
+        if version[0] == "{":
+            uncurled = version[1:-1]
+            uncurled_split = [x.strip() for x in uncurled.split(",")]
+
+            # find the version
+            for item in uncurled_split:
+                if "version" in item:
+                    item_split = [x.strip() for x in item.split("=", 2)]
+
+                    version = item_split[1][1:-1]
+                    if version != "*":
+                        package_version = version
+
+                    break
+        elif version != '"*"':
+            package_version = version[1:-1]
+
+        if package_version:
+            full_package = f"{package}{package_version}"
+
+        install_requires.append(full_package)
 
     return install_requires
 
@@ -35,7 +61,7 @@ setup(
     url="https://github.com/openslate/compose-flow",
     author="OpenSlate",
     author_email="code@openslate.com",
-    version="0.0.0",
+    use_scm_version=True,
     description="codified workflows for docker compose",
     long_description=readme(),
     long_description_content_type="text/markdown",

--- a/src/compose_flow/commands/subcommands/base.py
+++ b/src/compose_flow/commands/subcommands/base.py
@@ -107,7 +107,7 @@ class BaseSubcommand(ABC):
 
         This defaults to False
         """
-        config = get_config() or {}
+        config = get_config(self.workflow) or {}
         env = self.workflow.args.environment
 
         dirty_working_copy_okay = self.workflow.args.dirty or config.get(

--- a/src/compose_flow/commands/subcommands/base.py
+++ b/src/compose_flow/commands/subcommands/base.py
@@ -108,7 +108,7 @@ class BaseSubcommand(ABC):
         This defaults to False
         """
         config = get_config(self.workflow) or {}
-        env = self.workflow.args.environment
+        env = self.workflow.environment_name
 
         dirty_working_copy_okay = self.workflow.args.dirty or config.get(
             "options", {}

--- a/src/compose_flow/commands/subcommands/deploy.py
+++ b/src/compose_flow/commands/subcommands/deploy.py
@@ -40,7 +40,7 @@ class Deploy(BaseSubcommand, KubeMixIn):
             --prune
             --with-registry-auth
             --compose-file {self.workflow.profile.filename}
-            {self.workflow.args.config_name}"""
+            {self.workflow.config_name}"""
 
     def build_kubectl_command(self) -> list:
         self.switch_kube_context()

--- a/src/compose_flow/commands/subcommands/env.py
+++ b/src/compose_flow/commands/subcommands/env.py
@@ -218,11 +218,6 @@ class Env(BaseSubcommand):
 
                     data[k] = rendered
 
-        # set defaults when no value is set
-        for k, v in self.cf_env.items():
-            if k not in data:
-                data[k] = v
-
         if self.workflow.subcommand.update_version_env_vars:
             # regenerate the full docker image name
             self._docker_image = None
@@ -424,6 +419,11 @@ class Env(BaseSubcommand):
             # any upstream configuration
             for extended_config in extended_configs:
                 data.update(extended_config)
+
+            # set defaults when no value is set
+            for k, v in self.cf_env.items():
+                if k not in data:
+                    data[k] = v
         else:  # reset runtime variables
             data.update(self._rendered_config)
 

--- a/src/compose_flow/commands/subcommands/env.py
+++ b/src/compose_flow/commands/subcommands/env.py
@@ -236,7 +236,7 @@ class Env(BaseSubcommand):
 
         registry_domain = self.workflow.docker_image_prefix
         project_name = self.workflow.project_name
-        env = self.workflow.args.environment
+        env = self.workflow.environment_name
 
         docker_image = f"{registry_domain}/{project_name}:{env}"
 
@@ -312,7 +312,7 @@ class Env(BaseSubcommand):
         data = {}
 
         # when no environment is specified on the command line, do not load any docker config
-        environment = self.workflow.args.environment
+        environment = self.workflow.environment_name
         if not environment:
             return data
 
@@ -410,9 +410,9 @@ class Env(BaseSubcommand):
             return tag_version
 
         # default the tag version to the name of the environment
-        tag_version = self.workflow.args.environment
+        tag_version = self.workflow.environment_name
         try:
-            tag_version = utils.get_tag_version(default=self.workflow.args.environment)
+            tag_version = utils.get_tag_version(default=tag_version)
         except Exception as exc:
             subcommand = self.workflow.subcommand
 

--- a/src/compose_flow/commands/subcommands/env.py
+++ b/src/compose_flow/commands/subcommands/env.py
@@ -334,7 +334,11 @@ class Env(BaseSubcommand):
                 continue
 
             try:
-                key, value = line.split("=", 1)
+                line_split = line.split("=", 1)
+                if len(line_split) == 1:
+                    line_split.append("")
+
+                key, value = line_split
             except ValueError as exc:
                 self.logger.error(
                     f"ERROR: unable to parse line number {idx}, edit your env: {line}"

--- a/src/compose_flow/commands/subcommands/env.py
+++ b/src/compose_flow/commands/subcommands/env.py
@@ -78,8 +78,11 @@ class Env(BaseSubcommand):
         """
         Returns the environment backend to use
         """
+        return self.get_backend()
+
+    def get_backend(self, remote=None):
         backend_name = "local"
-        remote = self.workflow.args.remote
+        remote = remote or self.workflow.args.remote
         project_config = get_config(self.workflow)
 
         if remote is not None:
@@ -146,10 +149,6 @@ class Env(BaseSubcommand):
         """
         Prints the loaded config to stdout
         """
-        config_name = self.workflow.config_name
-        if config_name not in self.backend.ls():
-            return f"docker config named {config_name} not in backend={self.backend.__class__.__name__}"
-
         print(self.render())
 
     @property
@@ -334,7 +333,8 @@ class Env(BaseSubcommand):
             config_name = f"{self.workflow.args.environment}-{basename}"
 
         try:
-            content = self.backend.read(config_name)
+            backend = self.get_backend(remote=self.workflow.args.config_remote)
+            content = backend.read(config_name)
         except errors.NoSuchConfig as exc:
             if not self.is_missing_config_okay(exc):
                 raise

--- a/src/compose_flow/commands/subcommands/env.py
+++ b/src/compose_flow/commands/subcommands/env.py
@@ -68,7 +68,7 @@ class Env(BaseSubcommand):
         """
         backend_name = "local"
         remote = self.workflow.args.remote
-        project_config = get_config()
+        project_config = get_config(self.workflow)
 
         if remote is not None:
             project_backend_name = (

--- a/src/compose_flow/commands/subcommands/env.py
+++ b/src/compose_flow/commands/subcommands/env.py
@@ -105,7 +105,7 @@ class Env(BaseSubcommand):
 
             self.execute(f"{editor} {path}", _fg=True)
 
-            self.backend.write(self.workflow.args.config_name, path)
+            self.backend.write(self.workflow.config_name, path)
 
     def write(self) -> None:
         """
@@ -115,7 +115,7 @@ class Env(BaseSubcommand):
             self.render_buf(fh, runtime_config=False)
             fh.flush()
 
-            self.backend.write(self.workflow.args.config_name, fh.name)
+            self.backend.write(self.workflow.config_name, fh.name)
 
     @classmethod
     def fill_subparser(cls, parser, subparser):

--- a/src/compose_flow/commands/subcommands/profile.py
+++ b/src/compose_flow/commands/subcommands/profile.py
@@ -332,7 +332,7 @@ class Profile(BaseSubcommand):
 
                 for k, v in (
                     ("DOCKER_SERVICE", service_name),
-                    ("DOCKER_STACK", self.workflow.args.config_name),
+                    ("DOCKER_STACK", self.workflow.config_name),
                 ):
                     if k not in service_environment_d:
                         service_environment_d[k] = v

--- a/src/compose_flow/commands/subcommands/profile.py
+++ b/src/compose_flow/commands/subcommands/profile.py
@@ -460,7 +460,7 @@ class Profile(BaseSubcommand):
         """
         Returns the profile data found in the dc.yml file
         """
-        config = get_config()
+        config = get_config(self.workflow)
         if not config:
             return {}
 

--- a/src/compose_flow/commands/subcommands/profile.py
+++ b/src/compose_flow/commands/subcommands/profile.py
@@ -13,24 +13,9 @@ from .base import BaseSubcommand
 from compose_flow.compose import merge_profile
 from compose_flow.config import get_config
 from compose_flow.errors import EnvError, NoSuchProfile, ProfileError
-from compose_flow.utils import render, yaml_dump, yaml_load
+from compose_flow.utils import get_kv, render, yaml_dump, yaml_load
 
 COPY_ENV_VAR = "CF_COPY_ENV_FROM"
-
-
-def get_kv(item: str) -> tuple:
-    """
-    Returns the item split at equal
-    """
-    item_split = item.split("=", 1)
-    key = item_split[0]
-
-    try:
-        val = item_split[1]
-    except IndexError:
-        val = None
-
-    return key, val
 
 
 def listify_kv(d: dict) -> list:

--- a/src/compose_flow/commands/subcommands/publish.py
+++ b/src/compose_flow/commands/subcommands/publish.py
@@ -1,4 +1,6 @@
 import argparse
+import sys
+
 from typing import List
 
 from compose_flow.docker_image import DockerImage
@@ -28,9 +30,15 @@ class Publish(BaseBuildSubcommand):
         docker_images = set()
 
         profile = self.workflow.profile
-        for service_data in profile.data["services"].values():
+        for service_name, service_data in profile.data["services"].items():
             if service_data.get("build"):
                 tagged_image_name = service_data.get("image")
+                if not tagged_image_name:
+                    print(
+                        f"service_name={service_name} does not have an image directive",
+                        file=sys.stderr,
+                    )
+                    continue
                 docker_images.add(tagged_image_name)
 
         return list(docker_images)
@@ -40,6 +48,7 @@ class Publish(BaseBuildSubcommand):
         Returns a list of docker images built in the compose file
         """
         tagged_image_names = self.get_built_tagged_image_names()
+        print(tagged_image_names)
         docker_images = [
             DockerImage(
                 tagged_image_name=tagged_image_name,

--- a/src/compose_flow/commands/subcommands/remote.py
+++ b/src/compose_flow/commands/subcommands/remote.py
@@ -22,6 +22,7 @@ class Remote(BaseSubcommand):
 
     def __init__(self, *args, **kwargs):
         self._host = kwargs.pop("host", None)
+        self.name = kwargs.pop("name", None)
 
         super().__init__(*args, **kwargs)
 
@@ -105,7 +106,7 @@ class Remote(BaseSubcommand):
 
         args = self.workflow.args
         data = self.workflow.app_config
-        remote = args.remote
+        remote = self.name or args.remote
 
         try:
             self._host = data["remotes"][remote]["ssh"]

--- a/src/compose_flow/commands/subcommands/service.py
+++ b/src/compose_flow/commands/subcommands/service.py
@@ -151,7 +151,7 @@ class Service(BaseSubcommand):
         """
         Lists all the services for this stack
         """
-        proc = self.execute(f"docker stack services {self.workflow.args.config_name}")
+        proc = self.execute(f"docker stack services {self.workflow.config_name}")
 
         return proc.stdout.decode("utf8")
 
@@ -207,7 +207,7 @@ class Service(BaseSubcommand):
     @property
     def service_name(self):
         args = self.workflow.args
-        env = self.workflow.environment
+        config_name = self.workflow.config_name
 
         service_name = args.service_name
         if service_name:
@@ -217,4 +217,4 @@ class Service(BaseSubcommand):
         if not service_name:
             return
 
-        return f"{args.config_name}_{args.service}"
+        return f"{config_name}_{service_name}"

--- a/src/compose_flow/commands/subcommands/task.py
+++ b/src/compose_flow/commands/subcommands/task.py
@@ -32,7 +32,7 @@ class Task(BaseSubcommand):
     @property
     @lru_cache()
     def task_config(self):
-        config = get_config()
+        config = get_config(self.workflow)
         try:
             task = config["tasks"][self.task_name]
         except KeyError:

--- a/src/compose_flow/commands/subcommands/task.py
+++ b/src/compose_flow/commands/subcommands/task.py
@@ -72,7 +72,7 @@ class Task(BaseSubcommand):
     def is_dirty_working_copy_okay(self, exc: Exception) -> bool:
         dirty_working_copy_okay = super().is_dirty_working_copy_okay(exc)
 
-        if not dirty_working_copy_okay and self.workflow.args.environment in ("local",):
+        if not dirty_working_copy_okay and self.workflow.environment_name in ("local",):
             self.logger.warning(
                 (
                     "\n\n"

--- a/src/compose_flow/commands/workflow.py
+++ b/src/compose_flow/commands/workflow.py
@@ -10,6 +10,7 @@ to manage running services.
 import argparse
 import logging.config
 import os
+import pathlib
 import pkg_resources  # part of setuptools
 import sys
 
@@ -21,7 +22,7 @@ from .subcommands.profile import Profile
 from .subcommands.remote import Remote
 
 from .. import errors, settings
-from ..config import DC_CONFIG_ROOT
+from ..config import DC_CONFIG_ROOT, DEFAULT_DC_CONFIG_FILE
 from ..errors import CommandError, ErrorMessage
 from ..utils import get_repo_name, yaml_load
 
@@ -40,6 +41,9 @@ class Workflow(object):
 
         self.parser = self.get_argument_parser()
         self.args, self.args_remainder = self.parser.parse_known_args(self.argv)
+
+        self.config_basename = None
+        self.config_name = None
 
         self._set_arg_defaults()
 
@@ -78,10 +82,6 @@ class Workflow(object):
         return version_arg
 
     @property
-    def config_name(self):
-        return self.args.config_name or self.project_name  # pylint: disable=E1101
-
-    @property
     def docker_image_prefix(self):
         docker_image_prefix = self.app_config.get("build", {}).get("image_prefix")
         docker_image_prefix = docker_image_prefix or settings.DOCKER_IMAGE_PREFIX
@@ -112,7 +112,18 @@ class Workflow(object):
 
         # defaults for these args are set in _set_arg_defaults() below
         parser.add_argument("-c", "--config-name")
+        parser.add_argument(
+            "-C",
+            "--config-basename",
+            help="the configuration name without environment prefix",
+        )
         parser.add_argument("-e", "--environment")
+        parser.add_argument(
+            "-f",
+            "--compose-flow-filename",
+            type=pathlib.Path,
+            help=f"the compose-flow project file to use, defaults to using {DEFAULT_DC_CONFIG_FILE}",
+        )
         parser.add_argument("-p", "--profile")
         parser.add_argument(
             "-n",
@@ -213,12 +224,34 @@ class Workflow(object):
             self.args.remote = self.args.environment
 
         # the config name is generated from the environment and project name
-        if self.args.config_name is None:
-            prefix = ""
-            if self.args.environment:
-                prefix = f"{self.args.environment}-"
+        prefix = ""
+        if self.args.environment:
+            prefix = f"{self.args.environment}-"
 
-            self.args.config_name = f"{prefix}{self.project_name}"
+        config_basename = self.args.config_basename
+        config_name = self.args.config_name
+
+        if config_basename and config_name:
+            raise CommandError(
+                "only provide a config_name or config_basename, not both"
+            )
+
+        if config_basename:
+            self.config_name = f"{prefix}{config_basename}"
+            self.config_basename = config_basename
+        elif config_name:
+            if prefix:
+                if config_name and not config_name.startswith(prefix):
+                    raise CommandError(
+                        f"config_name must be prefixed with the environment, e.g. {prefix}{config_name}"
+                    )
+
+                self.config_name = config_name
+                self.config_basename = config_name.split(prefix, 1)[-1]
+        else:
+            # both config_name and config_basename are not set
+            self.config_basename = self.project_name
+            self.config_name = f"{prefix}{self.config_basename}"
 
     def _setup_environment(self):
         """

--- a/src/compose_flow/commands/workflow.py
+++ b/src/compose_flow/commands/workflow.py
@@ -37,7 +37,9 @@ CF_REMOTES_CONFIG_PATH = os.path.expanduser(
 
 class Workflow(object):
     def __init__(self, argv=None):
-        self.argv = argv or sys.argv[1:]
+        self.argv = argv
+        if argv is None:
+            self.argv = sys.argv[1:]
 
         self.parser = self.get_argument_parser()
         self.args, self.args_remainder = self.parser.parse_known_args(self.argv)

--- a/src/compose_flow/commands/workflow.py
+++ b/src/compose_flow/commands/workflow.py
@@ -103,6 +103,11 @@ class Workflow(object):
 
         return environment
 
+    @property
+    @lru_cache()
+    def environment_name(self):
+        return self.args.environment
+
     def get_argument_parser(self, doc: str = None):
         argparse.ArgumentParser.set_default_subparser = set_default_subparser
 

--- a/src/compose_flow/commands/workflow.py
+++ b/src/compose_flow/commands/workflow.py
@@ -124,6 +124,10 @@ class Workflow(object):
             "--config-basename",
             help="the configuration name without environment prefix",
         )
+        parser.add_argument(
+            "--config-remote",
+            help=f"the remote to use to retrieve the requested configuration",
+        )
         parser.add_argument("-e", "--environment")
         parser.add_argument(
             "-f",

--- a/src/compose_flow/commands/workflow.py
+++ b/src/compose_flow/commands/workflow.py
@@ -247,14 +247,10 @@ class Workflow(object):
             self.config_name = f"{prefix}{config_basename}"
             self.config_basename = config_basename
         elif config_name:
+            self.config_name = config_name
             if prefix:
-                if config_name and not config_name.startswith(prefix):
-                    raise CommandError(
-                        f"config_name must be prefixed with the environment, e.g. {prefix}{config_name}"
-                    )
-
-                self.config_name = config_name
-                self.config_basename = config_name.split(prefix, 1)[-1]
+                if config_name.startswith(prefix):
+                    self.config_basename = config_name.split(prefix, 1)[-1]
         else:
             # both config_name and config_basename are not set
             self.config_basename = self.project_name

--- a/src/compose_flow/config.py
+++ b/src/compose_flow/config.py
@@ -4,10 +4,14 @@ import typing
 
 from functools import lru_cache
 
-from compose_flow.utils import yaml_load
+from influxstats.logging import get_logger
+
+from compose_flow.utils import remerge, yaml_dump, yaml_load
 
 if typing.TYPE_CHECKING:
     from .commands.workflow import Workflow
+
+DictNone = typing.Union[dict, None]
 
 DEFAULT_DC_CONFIG_FILE = pathlib.Path("compose") / "compose-flow.yml"
 
@@ -17,12 +21,109 @@ DC_CONFIG_PATH = os.environ.get("DC_CONFIG_FILE", DEFAULT_DC_CONFIG_FILE)
 DC_CONFIG_ROOT, DC_CONFIG_FILE = os.path.split(DC_CONFIG_PATH)
 
 
-@lru_cache()
-def get_config(workflow: "Workflow") -> dict:
-    data = None
+# noinspection PyUnusedLocal
+def check_config(workflow: "Workflow", data: dict) -> dict:
+    if not data:
+        return data
 
-    if os.path.exists(DC_CONFIG_FILE):
-        with open(DC_CONFIG_FILE, "r") as fh:
-            data = yaml_load(fh)
+    # check for a compose_flow section
+    compose_flow = data.get("compose_flow", None)
+    if not compose_flow:
+        return data
+
+    extends = compose_flow.get("config", {}).get("extends")
+    if not extends:
+        return data
+
+    configs = []
+    for item in extends:
+        with open(item) as fh:
+            configs.append(yaml_load(fh))
+
+    # append the config that was read in to the configs list
+    configs.append(data)
+
+    # mash them together
+    data = remerge(configs)
+
+    return data
+
+
+def get_base_config_name(workflow: "Workflow") -> str:
+    """Returns the config name without the environment prefix
+
+    Args:
+        workflow: The running workflow
+    """
+    logger = get_logger()
+
+    base_config_name = workflow.config_name
+
+    # NOTE: use environment_name instead of environment because
+    # using the latter may cause a recursive loop
+    environment_prefix = f"{workflow.environment_name}-"
+
+    if base_config_name.startswith(environment_prefix):
+        base_config_name = base_config_name.split(environment_prefix, 1)[-1]
+
+    logger.debug(f"base_config_name={base_config_name}")
+
+    return base_config_name
+
+
+@lru_cache()
+def get_config(workflow: "Workflow") -> DictNone:
+    """Returns the compose-flow project config file
+
+    By default, this will check for a compose-flow file in compose/ with the same
+    name as the project name, e.g. compose/compose-flow.my-project.yml.  when a file with the
+    same name as the project is not found, the default file compose/compose-flow.yml
+    is used.
+
+    When `-f` is provided on the command line, that file is the only file searched,
+    and an exception will be raised when it is not found.
+    """
+    data = read_project_config(workflow) or {}
+
+    data = check_config(workflow, data)
+
+    return data
+
+
+def read_project_config(workflow: "Workflow") -> dict:
+    """Reads the project config from the filesystem
+    """
+    data = {}
+
+    logger = get_logger()
+
+    compose_flow_filename = workflow.args.compose_flow_filename
+
+    if compose_flow_filename:
+        paths = [compose_flow_filename]
+    else:
+        base_config_name = get_base_config_name(workflow)
+
+        config_name_config_file = f"compose-flow.{base_config_name}.yml"
+        project_name_config_file = f"compose-flow.{workflow.project_name}.yml"
+
+        paths = [config_name_config_file, project_name_config_file, DC_CONFIG_PATH]
+
+    for item in paths:
+        filename = os.path.basename(item)
+
+        logger.debug(f"looking for {filename}")
+
+        if os.path.exists(filename):
+            with open(filename, "r") as fh:
+                data = yaml_load(fh)
+
+                break
+
+        outfile = f"compose-flow-{workflow.environment_name}-{workflow.config_name}-config.yml"
+        with open(outfile, "w") as fh:
+            fh.write(yaml_dump(data))
+    else:
+        logger.warning(f"compose-flow config not found; tried {paths} in {os.getcwd()}")
 
     return data

--- a/src/compose_flow/config.py
+++ b/src/compose_flow/config.py
@@ -1,10 +1,13 @@
 import os
 import pathlib
+import typing
 
 from functools import lru_cache
 
 from compose_flow.utils import yaml_load
 
+if typing.TYPE_CHECKING:
+    from .commands.workflow import Workflow
 
 DEFAULT_DC_CONFIG_FILE = pathlib.Path("compose") / "compose-flow.yml"
 
@@ -15,7 +18,7 @@ DC_CONFIG_ROOT, DC_CONFIG_FILE = os.path.split(DC_CONFIG_PATH)
 
 
 @lru_cache()
-def get_config() -> dict:
+def get_config(workflow: "Workflow") -> dict:
     data = None
 
     if os.path.exists(DC_CONFIG_FILE):

--- a/src/compose_flow/config.py
+++ b/src/compose_flow/config.py
@@ -102,9 +102,7 @@ def read_project_config(workflow: "Workflow") -> dict:
     if compose_flow_filename:
         paths = [compose_flow_filename]
     else:
-        base_config_name = get_base_config_name(workflow)
-
-        config_name_config_file = f"compose-flow.{base_config_name}.yml"
+        config_name_config_file = f"compose-flow.{workflow.config_basename}.yml"
         project_name_config_file = f"compose-flow.{workflow.project_name}.yml"
 
         paths = [config_name_config_file, project_name_config_file, DC_CONFIG_PATH]

--- a/src/compose_flow/config.py
+++ b/src/compose_flow/config.py
@@ -117,11 +117,11 @@ def read_project_config(workflow: "Workflow") -> dict:
                 data = yaml_load(fh)
 
                 break
-
-        outfile = f"compose-flow-{workflow.environment_name}-{workflow.config_name}-config.yml"
-        with open(outfile, "w") as fh:
-            fh.write(yaml_dump(data))
     else:
         logger.warning(f"compose-flow config not found; tried {paths} in {os.getcwd()}")
+
+    outfile = f"compose-flow-{workflow.config_name}-config.yml"
+    with open(outfile, "w") as fh:
+        fh.write(yaml_dump(data))
 
     return data

--- a/src/compose_flow/docker_image.py
+++ b/src/compose_flow/docker_image.py
@@ -45,6 +45,8 @@ class DockerImage:
         Parse the tagged_image_name and set repository, image_name, semver version_info
         :return:
         """
+        print(f"_tagged_image_name={self._tagged_image_name}")
+
         self.repository = (
             self._tagged_image_name.split("/")[0]
             if "/" in self._tagged_image_name

--- a/src/compose_flow/environment/backends/__init__.py
+++ b/src/compose_flow/environment/backends/__init__.py
@@ -10,4 +10,6 @@ def get_backend(name: str, *args, **kwargs) -> object:
     module = importlib.import_module(module_path)
     backend_cls = getattr(module, f"{name.capitalize()}Backend")
 
-    return backend_cls(*args, **kwargs)
+    backend = backend_cls(*args, **kwargs)
+
+    return backend

--- a/src/compose_flow/environment/backends/base_backend.py
+++ b/src/compose_flow/environment/backends/base_backend.py
@@ -3,7 +3,11 @@ import logging
 
 class BaseBackend(object):
     def __init__(self, *args, **kwargs):
-        pass
+        workflow = kwargs.get("workflow")
+        if workflow:
+            self.workflow = workflow
+        else:
+            raise BackendError("must pass workflow")
 
     @property
     def logger(self):

--- a/src/compose_flow/kube/mixins.py
+++ b/src/compose_flow/kube/mixins.py
@@ -570,8 +570,10 @@ class KubeMixIn(object):
             content = fh.read()
 
         if not raw:
-            rendered = render(content, env=self.workflow.environment.data)
-            rendered = render_jinja(rendered, env=self.workflow.environment.data)
+            env = dict(get_kv(self.workflow.environment.render(), multiple=True))
+
+            rendered = render(content, env=env)
+            rendered = render_jinja(rendered, env=env)
         else:
             rendered = content
 

--- a/src/compose_flow/kube/mixins.py
+++ b/src/compose_flow/kube/mixins.py
@@ -122,7 +122,7 @@ class KubeMixIn(object):
 
     def _get_secret(self, name: str):
         return self.execute(
-            f"{self.kubectl_command} get secrets --namespace {self.namespace} -o yaml {self.secret_name}"
+            f"{self.kubectl_command} get secrets --namespace {self.namespace} -o yaml {name}"
         )
 
     def _read_secret_env(self, name: str) -> str:

--- a/src/compose_flow/kube/mixins.py
+++ b/src/compose_flow/kube/mixins.py
@@ -20,7 +20,7 @@ from compose_flow.kube.checks import (
     AnswersChecker,
     ValuesChecker,
 )
-from compose_flow.utils import render, render_jinja
+from compose_flow.utils import render, render_jinja, get_kv
 
 CLUSTER_LS_FORMAT = "{{.Cluster.Name}}: {{.Cluster.ID}}"
 PROJECT_LS_FORMAT = "{{.Project.Name}}: {{.Project.ID}}"

--- a/src/compose_flow/kube/mixins.py
+++ b/src/compose_flow/kube/mixins.py
@@ -40,7 +40,7 @@ class KubeMixIn(object):
     @property
     @lru_cache()
     def config(self):
-        return get_config()
+        return get_config(self.workflow)
 
     @property
     def rancher_config(self):
@@ -499,7 +499,7 @@ class KubeMixIn(object):
         return command
 
     def get_rke_deploy_command(self):
-        raw_config = get_config()["rke"]["config"]
+        raw_config = get_config(self.workflow)["rke"]["config"]
         rendered_config = f"compose-flow-{self.workflow.args.profile}-rke.yml"
         self.render_single_yaml(raw_config, rendered_config)
         return f"rke up --config {rendered_config}"

--- a/src/compose_flow/kube/mixins.py
+++ b/src/compose_flow/kube/mixins.py
@@ -465,7 +465,7 @@ class KubeMixIn(object):
     ) -> str:
         """Construct command to apply a Kubernetes YAML manifest using kubectl."""
 
-        deploy_label = self.workflow.args.config_name
+        deploy_label = self.workflow.config_name
 
         raw_path = manifest["path"]
         deploy_label = manifest.get("label")

--- a/src/compose_flow/utils.py
+++ b/src/compose_flow/utils.py
@@ -2,9 +2,11 @@ import base64
 import logging
 import re
 import os
-import yaml
 
+from typing import Iterable
 from collections import OrderedDict
+
+import yaml
 
 from boltons.iterutils import remap, get_path, default_enter, default_visit
 from jinja2 import Environment
@@ -15,6 +17,31 @@ from .errors import TagVersionError, EnvError, ProfileError
 
 # regular expression for finding variables in docker compose files
 VAR_RE = re.compile(r"\${(?P<varname>.*?)(?P<junk>[:?].*)?}")
+
+
+def _get_kv(item: str) -> tuple:
+    """
+    Returns the item split at equal
+    """
+    item_split = item.split("=", 1)
+    key = item_split[0]
+
+    try:
+        val = item_split[1]
+    except IndexError:
+        val = None
+
+    return key, val
+
+
+def get_kv(item: str, multiple: bool = False) -> Iterable[tuple]:
+    """Wrapper around _get_kv() to support multiple items in the string"""
+    items = [_get_kv(line) for line in item.splitlines()]
+
+    if multiple:
+        return items
+
+    return items[0]
 
 
 def get_repo_name() -> str:

--- a/src/tests/__init__.py
+++ b/src/tests/__init__.py
@@ -17,5 +17,4 @@ class BaseTestCase(TestCase):
         self.sh_patcher = mock.patch("compose_flow.shell.sh")
         self.sh_mock = self.sh_patcher.start()
 
-    def tearDown(self):
-        self.sh_patcher.stop()
+        self.addCleanup(self.sh_patcher.stop)

--- a/src/tests/test_env.py
+++ b/src/tests/test_env.py
@@ -91,6 +91,18 @@ class EnvTestCase(BaseTestCase):
         self.assertEqual(flow.config_name, "dev-testdirname")
 
     @mock.patch("compose_flow.commands.subcommands.env.get_backend")
+    def test_empty_env_value(self, *mocks):
+        """Ensure that a value can be empty if the line ends with an equals
+        """
+        get_backend_mock = mocks[0]
+        get_backend_mock.return_value.read.return_value = f"FOO="
+
+        command = shlex.split("-e dev env cat")
+        flow = Workflow(argv=command)
+
+        self.assertEquals("", flow.environment.data["FOO"])
+
+    @mock.patch("compose_flow.commands.subcommands.env.get_backend")
     def test_load_ro(self, *mocks):
         """
         Ensures that env.load does not reset the VERSION var

--- a/src/tests/test_env.py
+++ b/src/tests/test_env.py
@@ -10,6 +10,7 @@ from tests import BaseTestCase
 
 
 @mock.patch("compose_flow.commands.workflow.PROJECT_NAME", new="testdirname")
+@mock.patch("compose_flow.config.read_project_config", return_value=dict())
 class EnvTestCase(BaseTestCase):
     def test_backend_default(self, *mocks):
         """
@@ -52,11 +53,12 @@ class EnvTestCase(BaseTestCase):
 
         TODO: this should move to test_workflow
         """
-        command = shlex.split("-e dev --config-name=test env cat")
+        config_name = "dev-test"
+        command = shlex.split(f"-e dev --config-name={config_name} env cat")
         flow = Workflow(argv=command)
         env = Env(flow)
 
-        self.assertEqual(flow.config_name, "test")
+        self.assertEqual(flow.config_name, config_name)
 
     def test_data_not_loaded_when_cache_is_empty_dict(self, *mocks):
         workflow = mock.MagicMock()

--- a/src/tests/test_env.py
+++ b/src/tests/test_env.py
@@ -1,6 +1,6 @@
 import os
 import shlex
-from unittest import TestCase, mock
+from unittest import mock
 
 from compose_flow import errors
 from compose_flow.commands.subcommands.env import Env, RUNTIME_PLACEHOLDER
@@ -9,6 +9,7 @@ from compose_flow.commands import Workflow
 from tests import BaseTestCase
 
 
+# noinspection PyUnusedLocal
 @mock.patch("compose_flow.commands.workflow.PROJECT_NAME", new="testdirname")
 @mock.patch("compose_flow.config.read_project_config", return_value=dict())
 class EnvTestCase(BaseTestCase):
@@ -60,6 +61,7 @@ class EnvTestCase(BaseTestCase):
 
         self.assertEqual(flow.config_name, config_name)
 
+    # noinspection PyMethodMayBeStatic
     def test_data_not_loaded_when_cache_is_empty_dict(self, *mocks):
         workflow = mock.MagicMock()
         workflow.args.environment = None
@@ -74,8 +76,10 @@ class EnvTestCase(BaseTestCase):
         # prime the cache with an empty dict to ensure load is not called
         env._data = {}
 
+        # noinspection PyStatementEffect
         env.data
 
+        # noinspection PyUnresolvedReferences
         env.load.assert_not_called()
 
     def test_default_config_name(self, *mocks):
@@ -144,7 +148,10 @@ class EnvTestCase(BaseTestCase):
         os.environ["BAR"] = bar_env_val
 
         get_backend_mock = mocks[0]
-        get_backend_mock.return_value.read.return_value = f"FOO={RUNTIME_PLACEHOLDER}\nBAR={RUNTIME_PLACEHOLDER}\nVERSION={version}\nDOCKER_IMAGE={docker_image}"
+        get_backend_mock.return_value.read.return_value = (
+            f"FOO={RUNTIME_PLACEHOLDER}\nBAR={RUNTIME_PLACEHOLDER}\n"
+            f"VERSION={version}\nDOCKER_IMAGE={docker_image}"
+        )
 
         command = shlex.split("-e dev env cat")
         flow = Workflow(argv=command)
@@ -174,4 +181,5 @@ class EnvTestCase(BaseTestCase):
 
         assert os.environ.get("FOO") is None
         with self.assertRaises(errors.RuntimeEnvError):
+            # noinspection PyStatementEffect
             flow.profile.data["services"]

--- a/src/tests/test_kube_mixins.py
+++ b/src/tests/test_kube_mixins.py
@@ -1,0 +1,20 @@
+from unittest import TestCase, mock
+
+from compose_flow.kube.mixins import KubeMixIn
+
+
+class KubeMixInTestCase(TestCase):
+    def test_get_secret_name_param(self, *mocks):
+        """Ensure the name param is used when getting a secret
+        """
+        mixin = KubeMixIn()
+        mixin.workflow = mock.Mock(config_name="BAD")
+        mixin.namespace = "something"
+        mixin.execute = mock.Mock()
+
+        secret_name = "GOODNAME"
+        mixin._get_secret(secret_name)
+
+        mixin.execute.assert_called_with(
+            f"rancher kubectl get secrets --namespace something -o yaml {secret_name}"
+        )

--- a/src/tests/test_utils.py
+++ b/src/tests/test_utils.py
@@ -16,3 +16,17 @@ class RenderTestCase(TestCase):
         expected = f'      - /tmp/jenkins/{env["JOB_NAME"]}/{env["BUILD_NUMBER"]}:/usr/local/src/results'
 
         self.assertEqual(expected, rendered)
+
+    def test_get_kv(self, *mocks):
+        """Ensure a single item is parsed
+        """
+        data = utils.get_kv("FOO=one")
+
+        self.assertEqual(("FOO", "one"), data)
+
+    def test_get_kv_multiple(self, *mocks):
+        """Ensure multiple items are parsed
+        """
+        data = utils.get_kv("FOO=one\nBAR=two", multiple=True)
+
+        self.assertEqual([("FOO", "one"), ("BAR", "two")], data)

--- a/src/tests/test_workflow.py
+++ b/src/tests/test_workflow.py
@@ -23,6 +23,17 @@ class WorkflowTestCase(BaseTestCase):
         utils_mock.get_tag_version.return_value = "0.0.0"
         utils_mock.render.side_effect = lambda x, **kwargs: x
 
+    def test_config_name_with_different_env(self, *mocks):
+        """Ensure the config can have a different env prefix than the current env
+
+        This allows storage of environments other than the current one, for example, storing a default local config
+        in the dev remote so that multiple devs can access it to seed their environment
+        """
+        command = shlex.split("-e dev -c local-test-project env cat")
+        workflow = Workflow(argv=command)
+
+        self.assertEquals("local-test-project", workflow.config_name)
+
     def test_default_env_when_no_env_specified(self, *mocks):
         self._setup_docker_config_mock(*mocks)
         self._setup_utils_mock(*mocks)

--- a/src/tests/test_workflow.py
+++ b/src/tests/test_workflow.py
@@ -2,7 +2,6 @@ import shlex
 
 from unittest import TestCase, mock
 
-from compose_flow import utils
 from compose_flow.commands import Workflow
 
 from tests import BaseTestCase
@@ -13,11 +12,13 @@ TEST_PROJECT_NAME = "test_project_name"
 @mock.patch("compose_flow.commands.subcommands.env.utils")
 @mock.patch("compose_flow.commands.subcommands.env.get_backend")
 class WorkflowTestCase(BaseTestCase):
-    def _setup_docker_config_mock(self, *mocks):
+    @staticmethod
+    def _setup_docker_config_mock(*mocks):
         get_backend_mock = mocks[-2]
         get_backend_mock.return_value.read.return_value = f"FOO=1\nBAR=2"
 
-    def _setup_utils_mock(self, *mocks):
+    @staticmethod
+    def _setup_utils_mock(*mocks):
         utils_mock = mocks[-1]
         utils_mock.get_tag_version.return_value = "0.0.0"
         utils_mock.render.side_effect = lambda x, **kwargs: x
@@ -130,6 +131,7 @@ class WorkflowTestCase(BaseTestCase):
         print_mock.assert_called_with(version)
 
 
+# noinspection PyUnusedLocal
 @mock.patch("compose_flow.commands.workflow.PROJECT_NAME", new=TEST_PROJECT_NAME)
 class WorkflowArgsTestCase(TestCase):
     """
@@ -145,7 +147,7 @@ class WorkflowArgsTestCase(TestCase):
 
         self.assertEqual(None, workflow.args.environment)
         self.assertEqual(None, workflow.args.remote)
-        self.assertEqual(TEST_PROJECT_NAME, workflow.args.config_name)
+        self.assertEqual(TEST_PROJECT_NAME, workflow.config_name)
         self.assertEqual(TEST_PROJECT_NAME, workflow.project_name)
 
     def test_sensible_defaults_with_env(self, *mocks):
@@ -158,7 +160,7 @@ class WorkflowArgsTestCase(TestCase):
 
         self.assertEqual(env, workflow.args.environment)
         self.assertEqual(env, workflow.args.remote)
-        self.assertEqual(f"{env}-{TEST_PROJECT_NAME}", workflow.args.config_name)
+        self.assertEqual(f"{env}-{TEST_PROJECT_NAME}", workflow.config_name)
         self.assertEqual(TEST_PROJECT_NAME, workflow.project_name)
 
     def test_sensible_defaults_with_env_and_project(self, *mocks):
@@ -171,5 +173,5 @@ class WorkflowArgsTestCase(TestCase):
 
         self.assertEqual(env, workflow.args.environment)
         self.assertEqual(env, workflow.args.remote)
-        self.assertEqual(f"{env}-foo", workflow.args.config_name)
+        self.assertEqual(f"{env}-foo", workflow.config_name)
         self.assertEqual("foo", workflow.project_name)

--- a/src/tests/test_workflow.py
+++ b/src/tests/test_workflow.py
@@ -43,9 +43,7 @@ class WorkflowTestCase(BaseTestCase):
 
         env = workflow.environment
 
-        self.assertEqual(
-            ["CF_ENV", "CF_ENV_NAME", "CF_PROJECT"], sorted(env.data.keys())
-        )
+        self.assertEqual([], sorted(env.data.keys()))
 
     @mock.patch("compose_flow.commands.workflow.os")
     def test_docker_image_prefix_default(self, *mocks):
@@ -96,10 +94,7 @@ class WorkflowTestCase(BaseTestCase):
 
         env = workflow.environment
 
-        self.assertEqual(
-            ["BAR", "CF_ENV", "CF_ENV_NAME", "CF_PROJECT", "FOO"],
-            sorted(env.data.keys()),
-        )
+        self.assertEqual(["BAR", "FOO"], sorted(env.data.keys()))
         self.assertEqual("1", env.data["FOO"])
         self.assertEqual("2", env.data["BAR"])
 


### PR DESCRIPTION
The goal with this PR is to make it easier to work with monorepos that can serve multiple deployments.

Allow compose-flow to point to different `compose-flow.yml` files based on the desired configuration.  This makes it possible to have compose-flow settings that are specific to a config, for example, `compose-flow -e <env> -C ad-api [...]` will search for a `compose-flow.ad-api.yml` and fallback to `compose-flow.yml` when the file does not exist.

This PR also makes a distinction between a "config name" (e.g. `dev-ad-api`) and a "config basename" (`ad-api`) and allows them to be decoupled.
