### PR TITLE
Add support for URL manifest paths

### DIFF
--- a/src/compose_flow/commands/subcommands/deploy.py
+++ b/src/compose_flow/commands/subcommands/deploy.py
@@ -111,3 +111,5 @@ class Deploy(BaseSubcommand, KubeMixIn):
                 self.execute(command)
 
             env.write()
+
+        return command

--- a/src/tests/test_deploy.py
+++ b/src/tests/test_deploy.py
@@ -7,6 +7,8 @@ from compose_flow.commands.subcommands.profile import Profile
 
 from tests import BaseTestCase
 
+MANIFEST_URL = "https://raw.githubusercontent.com/jetstack/cert-manager/release-0.11/deploy/manifests/00-crds.yaml"
+
 
 @mock.patch("compose_flow.commands.subcommands.env.get_backend")
 @mock.patch("compose_flow.commands.subcommands.env.os")
@@ -183,3 +185,39 @@ class DeployTestCase(BaseTestCase):
         # make sure the new namespace is created
         mock_create_ns = mocks[0]
         mock_create_ns.assert_not_called()
+
+    @mock.patch(
+        "compose_flow.commands.subcommands.deploy.Deploy.switch_rancher_context"
+    )
+    @mock.patch(
+        "compose_flow.commands.subcommands.deploy.Deploy.get_apps", return_value=[]
+    )
+    @mock.patch(
+        "compose_flow.commands.subcommands.deploy.Deploy.get_rancher_manifests",
+        return_value=[MANIFEST_URL],
+    )
+    @mock.patch(
+        "compose_flow.commands.subcommands.deploy.Deploy.get_rancher_namespaces",
+        return_value=[],
+    )
+    @mock.patch(
+        "compose_flow.commands.subcommands.deploy.Deploy.list_rancher_namespaces",
+        return_value=["existing-namespace"],
+    )
+    @mock.patch(
+        "compose_flow.commands.subcommands.deploy.Deploy.create_rancher_namespace"
+    )
+    def test_rancher_url_manifest(self, *mocks):
+        """
+        Ensure that manifests can be deployed to Rancher from external URLs
+        """
+        command = shlex.split("-e dev --dry-run deploy rancher")
+        workflow = Workflow(argv=command)
+
+        workflow.environment.write = mock.Mock()
+        workflow.profile.check = mock.Mock()
+
+        command = workflow.run()
+
+        # make sure the logs contain the manifest URL
+        self.assertTrue(any(MANIFEST_URL in c for c in command))


### PR DESCRIPTION
Allows users to leverage `kubectl`'s native support for loading manifests from remote URLs