### PR TITLE
Avoid a non-zero exit code on deploy subcommand

### DIFF
--- a/src/compose_flow/commands/subcommands/deploy.py
+++ b/src/compose_flow/commands/subcommands/deploy.py
@@ -111,5 +111,3 @@ class Deploy(BaseSubcommand, KubeMixIn):
                 self.execute(command)
 
             env.write()
-
-        return command

--- a/src/tests/test_deploy.py
+++ b/src/tests/test_deploy.py
@@ -207,17 +207,20 @@ class DeployTestCase(BaseTestCase):
     @mock.patch(
         "compose_flow.commands.subcommands.deploy.Deploy.create_rancher_namespace"
     )
+    @mock.patch("compose_flow.commands.subcommands.deploy.Deploy.execute")
     def test_rancher_url_manifest(self, *mocks):
         """
         Ensure that manifests can be deployed to Rancher from external URLs
         """
-        command = shlex.split("-e dev --dry-run deploy rancher")
+        command = shlex.split("-e dev deploy rancher")
         workflow = Workflow(argv=command)
 
         workflow.environment.write = mock.Mock()
         workflow.profile.check = mock.Mock()
 
-        command = workflow.run()
+        workflow.run()
 
-        # make sure the logs contain the manifest URL
-        self.assertTrue(any(MANIFEST_URL in c for c in command))
+        command = mocks[0].call_args[0][0]
+
+        # make sure the command contains the manifest URL
+        self.assertTrue(MANIFEST_URL in command)


### PR DESCRIPTION
`deploy` was throwing a non-zero exit code because I returned the command as a message for testing purposes

This will only return the command if `--dry-run` is passed