### PR TITLE
Ignore .eggs directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ __pycache__
 results
 build/
 dist/
+.eggs/


### PR DESCRIPTION
Ignore `.eggs` directory so publish works again.