### PR TITLE
Upgrade CLI tools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,8 @@ RUN groupadd -g ${gid} ${group} \
  && chmod -R 770 $HOME
 
 # Install Docker client
-ENV DOCKERVERSION="18.09.5"
-ENV DOCKER_SHA="ac485ffe7ea3f43974c4613d5142eae7ec67a611"
+ENV DOCKERVERSION="19.03.4"
+ENV DOCKER_SHA="5b9aa113916cfdde3eaf2bd25d2b8c3da49e0268"
 RUN curl -fsSLO https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKERVERSION}.tgz \
  && echo "$DOCKER_SHA docker-${DOCKERVERSION}.tgz" | sha1sum -c - \
  && tar xzvf docker-${DOCKERVERSION}.tgz --strip 1 \
@@ -27,24 +27,24 @@ RUN groupadd -for -g ${DOCKER_GID} docker \
  && usermod -a -G docker,staff ${user}
 
 # Install kubectl
-ENV KUBE_LATEST_VERSION="v1.13.0"
-ENV KUBE_SHA="5c619006fa45afce6efc51db819aff7d5ba7ef0e"
+ENV KUBE_LATEST_VERSION="v1.16.9"
+ENV KUBE_SHA="32d5cf4b60d1e0c87cecf3ccb9c57011bfc5af4b"
 RUN curl -L https://storage.googleapis.com/kubernetes-release/release/${KUBE_LATEST_VERSION}/bin/linux/amd64/kubectl -o /usr/local/bin/kubectl \
  && echo "$KUBE_SHA /usr/local/bin/kubectl" | sha1sum -c - \
  && chmod +x /usr/local/bin/kubectl
 
 # Install Rancher CLI
-ENV RANCHER_VERSION="v2.2.0"
-ENV RANCHER_SHA="dcd076643b39891b9f0a8c7da746ee73e0d9735c"
+ENV RANCHER_VERSION="v2.4.3"
+ENV RANCHER_SHA="e3c4888f7ecce7c89cd5ff1b45e8637435f74f2839b468ddd41aaddb815c9fea"
 RUN curl -fsSLO https://github.com/rancher/cli/releases/download/${RANCHER_VERSION}/rancher-linux-amd64-${RANCHER_VERSION}.tar.gz \
- && echo "$RANCHER_SHA rancher-linux-amd64-${RANCHER_VERSION}.tar.gz" | sha1sum -c - \
+ && echo "$RANCHER_SHA rancher-linux-amd64-${RANCHER_VERSION}.tar.gz" | sha256sum -c - \
  && tar xzvf rancher-linux-amd64-${RANCHER_VERSION}.tar.gz --strip 2 \
     -C /usr/local/bin \
  && rm rancher-linux-amd64-${RANCHER_VERSION}.tar.gz
 
 # Install Helm client
-ENV HELM_VERSION="v2.11.0"
-ENV HELM_SHA="70fbc46e40bb3e564e91f438f9b644532b0dfcad"
+ENV HELM_VERSION="v2.16.7"
+ENV HELM_SHA="7556a4c2dfc41d31f7a7252f129eff9fe030eccf"
 RUN curl -fsSLO https://storage.googleapis.com/kubernetes-helm/helm-${HELM_VERSION}-linux-amd64.tar.gz \
  && echo "$HELM_SHA helm-${HELM_VERSION}-linux-amd64.tar.gz" | sha1sum -c - \
  && tar xzvf helm-${HELM_VERSION}-linux-amd64.tar.gz --strip 1 \


### PR DESCRIPTION
Contributes to https://openslate.myjetbrains.com/youtrack/issue/OS-2997

The main purpose of this PR was to upgrade `rancher` to get some nice bugdfixes, but we haven't upgraded `docker`, `kubectl`, `rancher` or `helm` in awhile - we should do so since things will break eventually